### PR TITLE
Добавлена возможность интроспекции стадий артефактов

### DIFF
--- a/lib/dapp/artifact.rb
+++ b/lib/dapp/artifact.rb
@@ -1,6 +1,10 @@
 module Dapp
   # Artifact
   class Artifact < Dimg
+    def stage_should_be_introspected?(name)
+      project.cli_options[:introspect_artifact_stage] == name
+    end
+
     def artifact?
       true
     end

--- a/lib/dapp/build/stage/mod/logging.rb
+++ b/lib/dapp/build/stage/mod/logging.rb
@@ -91,7 +91,7 @@ module Dapp
           end
 
           def should_be_introspected?
-            dimg.project.cli_options[:introspect_stage] == name && !dimg.project.dry_run? && !dimg.artifact?
+            dimg.stage_should_be_introspected?(name) && !dimg.project.dry_run?
           end
 
           def should_be_quiet?

--- a/lib/dapp/cli/build.rb
+++ b/lib/dapp/cli/build.rb
@@ -40,7 +40,14 @@ BANNER
              proc: proc { |v| v.to_sym },
              in: [nil, :from, :before_install, :before_install_artifact, :g_a_archive, :g_a_pre_install_patch, :install,
                   :g_a_post_install_patch, :after_install_artifact, :before_setup, :before_setup_artifact, :g_a_pre_setup_patch,
-                  :chef_cookbooks, :setup, :g_a_post_setup_patch, :after_setup_artifact, :g_a_latest_patch, :docker_instructions]
+                  :setup, :chef_cookbooks, :g_a_post_setup_patch, :after_setup_artifact, :g_a_latest_patch, :docker_instructions]
+
+      option :introspect_artifact_stage,
+             long: '--introspect-artifact-stage STAGE',
+             proc: proc { |v| v.to_sym },
+             in: [nil, :from, :before_install, :before_install_artifact, :g_a_archive, :g_a_pre_install_patch, :install,
+                  :g_a_post_install_patch, :after_install_artifact, :before_setup, :before_setup_artifact, :g_a_pre_setup_patch,
+                  :setup, :chef_cookbooks, :after_setup_artifact, :g_a_artifact_patch, :build_artifact]
 
       option :ssh_key,
              long: '--ssh-key SSH_KEY',

--- a/lib/dapp/dimg.rb
+++ b/lib/dapp/dimg.rb
@@ -162,6 +162,10 @@ module Dapp
       artifacts.each(&:cleanup_tmp)
     end
 
+    def stage_should_be_introspected?(name)
+      project.cli_options[:introspect_stage] == name
+    end
+
     protected
 
     def should_be_built?


### PR DESCRIPTION
- Опция при сборке '--introspect-artifact-stage STAGE'.
- При существовании нескольких артефактов:
  - Интроспект отрабатывает для STAGE каждого артефакта.
  - Для того, чтобы перейти к интроспекции STAGE конкретного артефакта, необходимо вручную выходить из интроспекции предыдущих (exit).