### PR TITLE
Изменена логика наследования mount-ов

### DIFF
--- a/lib/dapp/version.rb
+++ b/lib/dapp/version.rb
@@ -1,5 +1,5 @@
 # Version
 module Dapp
   VERSION = '0.7.27'.freeze
-  BUILD_CACHE_VERSION = 6
+  BUILD_CACHE_VERSION = 7
 end


### PR DESCRIPTION
- Используются mount-ы, которые присутствуют в Dappfile и в лейблах базового образа.
- Эти же mount-ы добавляются в лейблы конечного образа и переиспользуются в других проектах, где этот образ будет использован в качестве базового.