### PR TITLE
Изменены зависимости у git artifact стадий

### DIFF
--- a/lib/dapp/build/stage/ga_dependencies_base.rb
+++ b/lib/dapp/build/stage/ga_dependencies_base.rb
@@ -11,7 +11,7 @@ module Dapp
         end
 
         def empty?
-          dimg.git_artifacts.empty? ? true : false
+          dimg.git_artifacts.empty? || super
         end
       end # GADependenciesBase
     end # Stage

--- a/lib/dapp/build/stage/ga_latest_patch.rb
+++ b/lib/dapp/build/stage/ga_latest_patch.rb
@@ -31,7 +31,7 @@ module Dapp
         end
 
         def empty?
-          dependencies_empty?
+          dependencies_empty? || dimg.git_artifacts.all? { |git_artifact| !git_artifact.any_changes?(prev_g_a_stage.layer_commit(git_artifact)) }
         end
 
         private

--- a/lib/dapp/build/stage/install/ga_pre_install_patch_dependencies.rb
+++ b/lib/dapp/build/stage/install/ga_pre_install_patch_dependencies.rb
@@ -14,10 +14,6 @@ module Dapp
           def dependencies
             next_stage.next_stage.context # Install
           end
-
-          def empty?
-            super || dependencies_empty?
-          end
         end # GAPreInstallPatchDependencies
       end
     end # Stage

--- a/spec/integration/dimg_spec.rb
+++ b/spec/integration/dimg_spec.rb
@@ -104,13 +104,7 @@ describe Dapp::Dimg do
   end
 
   def change_g_a_post_setup_patch
-    file_path = project_path.join('large_file')
-    if File.exist? file_path
-      FileUtils.rm file_path
-      git_commit!
-    else
-      git_change_and_commit!('large_file', 'x' * 1024 * 1024)
-    end
+    git_change_and_commit!('large_file', random_string(Dapp::Build::Stage::SetupGroup::GAPostSetupPatchDependencies::MAX_PATCH_SIZE))
   end
 
   def change_g_a_latest_patch

--- a/spec/spec_helper/common.rb
+++ b/spec/spec_helper/common.rb
@@ -17,8 +17,8 @@ module SpecHelper
       shellout(*args, **kwargs).tap(&:error!)
     end
 
-    def random_string
-      (('a'..'z').to_a * 10).sample(100).join
+    def random_string(n = 10)
+      (('a'..'z').to_a * n).sample(n).join
     end
 
     def generate_command


### PR DESCRIPTION
- git artifact стадии собираются только если существуют:
  - git artifact-ы.
  - Cоответствующие зависимости.
- Дополнительным условием для стадий ga_latest_patch и ga_artifact_patch является наличие изменений, непустых патчей.

Уменьшен потенциальный размер собираемого кеша.