### PR TITLE
Доработано кеширование атрибутов стадий

### DIFF
--- a/lib/dapp/build/stage/base.rb
+++ b/lib/dapp/build/stage/base.rb
@@ -122,16 +122,18 @@ module Dapp
         end
 
         def signature
-          if empty?
-            prev_stage.signature
-          else
-            args = []
-            args << prev_stage.signature unless prev_stage.nil?
-            args << dimg.build_cache_version
-            args << builder_checksum
-            args.concat(dependencies.flatten)
+          @signature ||= begin
+            if empty?
+              prev_stage.signature
+            else
+              args = []
+              args << prev_stage.signature unless prev_stage.nil?
+              args << dimg.build_cache_version
+              args << builder_checksum
+              args.concat(dependencies.flatten)
 
-            hashsum args
+              hashsum args
+            end
           end
         end
 

--- a/lib/dapp/build/stage/build_artifact.rb
+++ b/lib/dapp/build/stage/build_artifact.rb
@@ -28,7 +28,7 @@ module Dapp
         private
 
         def artifact_dependencies_files_checksum
-          @artifact_files_checksum ||= dependencies_files_checksum(dimg.config._artifact_dependencies)
+          dependencies_files_checksum(dimg.config._artifact_dependencies)
         end
       end # BuildArtifact
     end # Stage

--- a/lib/dapp/build/stage/import_artifact.rb
+++ b/lib/dapp/build/stage/import_artifact.rb
@@ -8,7 +8,7 @@ module Dapp
         end
 
         def signature
-          hashsum [*dependencies.flatten, change_options]
+          @signature ||= hashsum [*dependencies.flatten, change_options]
         end
 
         def image

--- a/lib/dapp/build/stage/install/install.rb
+++ b/lib/dapp/build/stage/install/install.rb
@@ -31,7 +31,7 @@ module Dapp
           private
 
           def install_dependencies_files_checksum
-            @install_dependencies_files_checksum ||= dependencies_files_checksum(dimg.config._install_dependencies)
+            dependencies_files_checksum(dimg.config._install_dependencies)
           end
         end # Install
       end

--- a/lib/dapp/build/stage/setup/setup.rb
+++ b/lib/dapp/build/stage/setup/setup.rb
@@ -31,7 +31,7 @@ module Dapp
           private
 
           def setup_dependencies_files_checksum
-            @setup_files_checksum ||= dependencies_files_checksum(dimg.config._setup_dependencies)
+            dependencies_files_checksum(dimg.config._setup_dependencies)
           end
         end # Setup
       end


### PR DESCRIPTION
- отказ от кеширования *_dependencies_files_checksum в пользу кеширование signature.
  - signature используется многократно;
  - кешируются вычисления сразу всех dependencies.