### PR TITLE
Пример использования артефакта для установки chefinit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.bundle
 /.vendor
 /spec/chef/testproject/.dapp_build
+/spec/chef/testproject2/.dapp_build

--- a/spec/chef/testproject2/.chefinit/Berksfile
+++ b/spec/chef/testproject2/.chefinit/Berksfile
@@ -1,0 +1,4 @@
+source 'https://supermarket.chef.io'
+
+cookbook 'apt'
+cookbook 'git'

--- a/spec/chef/testproject2/Dappfile
+++ b/spec/chef/testproject2/Dappfile
@@ -1,0 +1,32 @@
+dimg do
+  docker.from 'centos:7'
+
+  artifact do
+    docker.from 'spheromak/docker-chefdk:latest'
+
+    git do
+      add '/spec/chef/testproject2/.chefinit' do
+        to '/chefinit'
+
+        stage_dependencies do
+          build_artifact '/spec/chef/testproject2/Berksfile'
+        end
+      end
+    end
+
+    shell do
+      build_artifact do
+        run 'cd /chefinit && /opt/chefdk/bin/berks vendor /cookbooks'
+      end
+    end
+
+    export '/cookbooks' do
+      before :install
+      to '/cookbooks'
+    end
+  end
+
+  git do
+    add { to '/app' }
+  end
+end


### PR DESCRIPTION
Тестовый проект spec/chef/testproject2 для установки chefinit cookbook'ов через артефакт.
closes #106

Рассматривать и принимать после решения проблем: #116, #118.