### PR TITLE
Правки связанные с работой git-артефакта

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.bundle
 /.vendor
 /spec/chef/testproject/.dapp_build
+/spec/chef/testproject2/.dapp_build

--- a/lib/dapp/dapp.rb
+++ b/lib/dapp/dapp.rb
@@ -78,7 +78,7 @@ module Dapp
 
     def local_git_artifact_exclude_paths(&blk)
       super do |exclude_paths|
-        build_path_relpath = Pathname.new(build_path).subpath_of(path)
+        build_path_relpath = Pathname.new(build_path).subpath_of(File.dirname(git_path))
         exclude_paths << build_path_relpath.to_s if build_path_relpath
 
         yield exclude_paths if block_given?

--- a/lib/dapp/dimg/git_artifact.rb
+++ b/lib/dapp/dimg/git_artifact.rb
@@ -225,7 +225,7 @@ module Dapp
       end
 
       def exclude_paths(with_cwd = false)
-        base_paths(repo.exclude_paths + @exclude_paths, with_cwd)
+        repo.exclude_paths + base_paths(@exclude_paths, with_cwd)
       end
 
       def include_paths(with_cwd = false)

--- a/lib/dapp/dimg/git_repo/own.rb
+++ b/lib/dapp/dimg/git_repo/own.rb
@@ -18,7 +18,7 @@ module Dapp
 
         def diff(from, to, **kwargs)
           if to.nil?
-            git.lookup(from).diff_workdir
+            git.lookup(from).diff_workdir(**kwargs)
           else
             super
           end

--- a/spec/chef/testproject2/.chefinit/Berksfile
+++ b/spec/chef/testproject2/.chefinit/Berksfile
@@ -1,0 +1,4 @@
+source 'https://supermarket.chef.io'
+
+cookbook 'apt'
+cookbook 'git'

--- a/spec/chef/testproject2/Dappfile
+++ b/spec/chef/testproject2/Dappfile
@@ -1,0 +1,32 @@
+dimg do
+  docker.from 'centos:7'
+
+  artifact do
+    docker.from 'spheromak/docker-chefdk:latest'
+
+    git do
+      add '/spec/chef/testproject2/.chefinit' do
+        to '/chefinit'
+
+        stage_dependencies do
+          build_artifact '/spec/chef/testproject2/Berksfile'
+        end
+      end
+    end
+
+    shell do
+      build_artifact do
+        run 'cd /chefinit && /opt/chefdk/bin/berks vendor /cookbooks'
+      end
+    end
+
+    export '/cookbooks' do
+      before :install
+      to '/cookbooks'
+    end
+  end
+
+  git do
+    add { to '/app' }
+  end
+end


### PR DESCRIPTION
* GitRepo::Own#diff:  в diff-e между деревом определённого комита и деревом рабочей директории отсутствовали опции.
* GitArtifact#exclude_paths: лишние преобразования путей системных файлов.
* Dapp#local_git_artifact_exclude_paths: пути системных файлов были относительно директории с Dappfile-ом, а не родительской директории .git.