### PR TITLE
Замена стадии chef_cookbooks: пример

### DIFF
--- a/spec/chef/testproject2/.chefinit/Berksfile
+++ b/spec/chef/testproject2/.chefinit/Berksfile
@@ -2,3 +2,5 @@ source 'https://supermarket.chef.io'
 
 cookbook 'apt'
 cookbook 'git'
+cookbook 'build-essential'
+cookbook '1password'

--- a/spec/chef/testproject2/.chefinit/Berksfile.lock
+++ b/spec/chef/testproject2/.chefinit/Berksfile.lock
@@ -1,0 +1,27 @@
+DEPENDENCIES
+  1password
+  apt
+  build-essential
+  git
+
+GRAPH
+  1password (1.3.0)
+  apt (6.0.1)
+  build-essential (8.0.0)
+    mingw (>= 1.1)
+    seven_zip (>= 0.0.0)
+  compat_resource (12.16.3)
+  dmg (3.1.0)
+  git (6.0.0)
+    build-essential (>= 0.0.0)
+    dmg (>= 0.0.0)
+    yum-epel (>= 0.0.0)
+  mingw (2.0.0)
+    seven_zip (>= 0.0.0)
+  ohai (5.0.0)
+  seven_zip (2.0.2)
+    windows (>= 1.2.2)
+  windows (3.0.1)
+    ohai (>= 4.0.0)
+  yum-epel (2.1.1)
+    compat_resource (>= 12.16.3)

--- a/spec/chef/testproject2/Dappfile
+++ b/spec/chef/testproject2/Dappfile
@@ -9,7 +9,7 @@ dimg do
         to '/chefinit'
 
         stage_dependencies do
-          build_artifact '/spec/chef/testproject2/Berksfile'
+          build_artifact 'Berksfile', 'Berksfile.lock'
         end
       end
     end
@@ -22,11 +22,7 @@ dimg do
 
     export '/cookbooks' do
       before :install
-      to '/cookbooks'
+      to '/usr/share/dapp/chef_repo/cookbooks'
     end
-  end
-
-  git do
-    add { to '/app' }
   end
 end


### PR DESCRIPTION
Тестовый проект spec/chef/testproject2 содержит Dappfile, в котором описан артефакт, производящий установку кукбуков при изменении файлов из git-репо Berksfile или Berksfile.lock. Cookbook'и устанавливаются в прежнее местоположение в /usr/share/dapp/chef_repo/cookbooks/ в конечном
образе.

resolve #129