### PR TITLE
Доработана логика очищения mount-ов

### DIFF
--- a/lib/dapp/dimg/build/stage/from.rb
+++ b/lib/dapp/dimg/build/stage/from.rb
@@ -26,8 +26,8 @@ module Dapp
             [:tmp_dir, :build_dir].map { |type| config_mounts_by_type(type) }.flatten.uniq
           end
 
-          def adding_mounts_by_type(type)
-            labels_mounts_by_type(type)
+          def adding_mounts_by_type(_type)
+            []
           end
 
           def should_not_be_detailed?


### PR DESCRIPTION
* отключается монтирование внешних директорий на стадии from.
  * mount-ы из label-ов базового образа могут пересекаться с Dappfile mount-ами, что может привести к удалению данных из временных директорий используемых между сборками.