### PR TITLE
Ошибка в кешировании контрольной суммы стадии chef сборщика

### DIFF
--- a/lib/dapp/dimg/builder/chef.rb
+++ b/lib/dapp/dimg/builder/chef.rb
@@ -115,7 +115,7 @@ module Dapp
       end
 
       def stage_cookbooks_checksum_path(stage)
-        dimg.build_path.join("#{builder_cookbook.checksum}.#{stage}.checksum")
+        dimg.build_path.join("#{builder_cookbook.checksum}.#{dimg.config._name}.#{stage}.checksum")
       end
 
       def stage_cookbooks_checksum(stage)


### PR DESCRIPTION
Контрольная сумма кешировалась без учета разделения кеша по разным dimg. Из-за этого возникала проблема с тем, что пересборка не запускалась для тех dimg, которые стоят в конфигурации после неизмененного dimg.