### PR TITLE
Генерация директивы depends для metadata.rb

### DIFF
--- a/lib/dapp/dimg/builder/chef/cookbook_metadata.rb
+++ b/lib/dapp/dimg/builder/chef/cookbook_metadata.rb
@@ -98,6 +98,10 @@ module Dapp
           [].tap do |lines|
             lines << "name #{@metadata.name.inspect}\n"
             lines << "version #{@metadata.version.inspect}\n"
+
+            @cookbooks.keys.each do |cookbook|
+              lines << "depends #{cookbook.inspect}\n" unless cookbook.start_with? 'dimod-'
+            end
           end.join
         end
       end # FromConfBuilder


### PR DESCRIPTION
Решение проблемы с неработающими cookbook'ами, которые указали в зависимостях. Не хватало генерации директивы depends для metadata.rb для указанных в Dappfile зависимостей. dimod-cookbook'и в depends не добавляются, т.к. рецепты оттуда указываются напрямую в runlist.

Проявляется, когда указываешь coobook-зависимость и пытаешься использовать из рецепта проекта (не dimod) — падает.