### PR TITLE
Поправлено регулярное выражение проверки docker репозитория

### DIFF
--- a/lib/dapp/dimg/docker_registry.rb
+++ b/lib/dapp/dimg/docker_registry.rb
@@ -15,13 +15,9 @@ module Dapp
       end
 
       def self.repo_name_format
-        separator = '[_.]|__|[-]*'
-        alpha_numeric = '[[:alnum:]]*'
-        component = "#{alpha_numeric}[#{separator}#{alpha_numeric}]*"
-        port_number = '[[:digit:]]+'
-        hostcomponent = '[[:alnum:]_-]*[[:alnum:]]'
-        hostname = "#{hostcomponent}[\\.#{hostcomponent}]*(?<port>:#{port_number})?"
-        "(?<hostname>#{hostname}/)?(?<repo_suffix>#{component}[/#{component}]*)"
+        rpart = '[a-z0-9]+(([_.]|__|-+)[a-z0-9]+)*'
+        hpart = '(?!-)[a-z0-9-]+(?<!-)'
+        "(?<hostname>#{hpart}(\\.#{hpart})*(?<port>:[0-9]+)?\/)?(?<repo_suffix>#{rpart}(\/#{rpart})*)"
       end
 
       def self.repo_name?(name)

--- a/lib/dapp/dimg/image/docker.rb
+++ b/lib/dapp/dimg/image/docker.rb
@@ -72,9 +72,7 @@ module Dapp
 
         class << self
           def image_name_format
-            separator = '[_.]|__|[-]*'
-            tag = "[[:alnum:]][[[:alnum:]]#{separator}]{0,127}"
-            "#{DockerRegistry.repo_name_format}(:(?<tag>#{tag}))?"
+            "#{DockerRegistry.repo_name_format}(:(?<tag>(?![-.])[a-zA-Z0-9_.-]{1,127}))?"
           end
 
           def image_name?(name)

--- a/spec/unit/docker_registry_spec.rb
+++ b/spec/unit/docker_registry_spec.rb
@@ -9,14 +9,14 @@ describe Dapp::Dimg::DockerRegistry do
     ].each do |str, repo_suffix, hostname|
       it str do
         str =~ %r{^#{Dapp::Dimg::DockerRegistry.repo_name_format}$}
-        expect(hostname).to eq Regexp.last_match(:hostname)
-        expect(repo_suffix).to eq Regexp.last_match(:repo_suffix)
+        expect(Regexp.last_match(:hostname)).to eq hostname
+        expect(Regexp.last_match(:repo_suffix)).to eq repo_suffix
       end
     end
   end
 
   context 'negative' do
-    %w(hostname.ru:6000 hostname:/repo).each do |str|
+    %w(hostname.ru:6000 hostname:/repo hostname- Hostname).each do |str|
       it str do
         expect(Dapp::Dimg::DockerRegistry.repo_name?(str)).to be_falsey
       end

--- a/spec/unit/image_docker_spec.rb
+++ b/spec/unit/image_docker_spec.rb
@@ -3,21 +3,22 @@ require_relative '../spec_helper'
 describe Dapp::Dimg::Image::Docker do
   context 'positive' do
     [
-      %w(image image),
+      %w(i i),
+      %w(i-m i-m),
       %w(image:tag.012 image tag.012),
-      %w(docker_registry:8000/image:tag image tag docker_registry:8000/)
+      %w(docker-registry:8000/image:tag image tag docker-registry:8000/)
     ].each do |str, repo_suffix, tag, hostname|
       it str do
         str =~ %r{^#{Dapp::Dimg::Image::Docker.image_name_format}$}
-        expect(hostname).to eq Regexp.last_match(:hostname)
-        expect(repo_suffix).to eq Regexp.last_match(:repo_suffix)
-        expect(tag).to eq Regexp.last_match(:tag)
+        expect(Regexp.last_match(:hostname)).to eq hostname
+        expect(Regexp.last_match(:repo_suffix)).to eq repo_suffix
+        expect(Regexp.last_match(:tag)).to eq tag
       end
     end
   end
 
   context 'negative' do
-    %w(image: image:tag:tag image:-tag).each do |image|
+    %w(image: image:tag:tag image:-tag image:.tag Image:tag).each do |image|
       it image do
         expect(Dapp::Dimg::Image::Docker.image_name?(image)).to be_falsey
       end


### PR DESCRIPTION
resolves #143
* имя репозитория не может содержать прописных букв.
* имя репозитория может состоять из одного символа.