### PR TITLE
Использование dappdeps слинкованных с glibc 2.5

### DIFF
--- a/lib/dapp/dapp/deps/base.rb
+++ b/lib/dapp/dapp/deps/base.rb
@@ -2,7 +2,7 @@ module Dapp
   class Dapp
     module Deps
       module Base
-        BASE_VERSION = '0.1.14'.freeze
+        BASE_VERSION = '0.1.15'.freeze
 
         def base_container_name # FIXME: hashsum(image) or dockersafe()
           "dappdeps_base_#{BASE_VERSION}"

--- a/lib/dapp/dimg/builder/chef.rb
+++ b/lib/dapp/dimg/builder/chef.rb
@@ -1,7 +1,7 @@
 module Dapp
   module Dimg
     class Builder::Chef < Builder::Base
-      DEFAULT_CHEFDK_IMAGE = 'dappdeps/chefdk:0.17.3-1'.freeze # TODO: config, DSL, DEFAULT_CHEFDK_IMAGE
+      DEFAULT_CHEFDK_IMAGE = 'dappdeps/chefdk:1.2.22-1'.freeze # TODO: config, DSL, DEFAULT_CHEFDK_IMAGE
 
       %i(before_install install before_setup setup build_artifact).each do |stage|
         define_method("#{stage}?") {!stage_empty?(stage)}


### PR DESCRIPTION
* Актуализирована версия chefdk до 1.2.22
* Версии dappdeps образов
  * dappdeps/base:0.1.15
  * dappdeps/chefdk:1.2.22-1
* Открывает возможность использования, например ubuntu:10.04 и centos:5 в качестве базового образа в docker.from
