### PR TITLE
Поправлено условие сборки стадии g_a_artifact_patch

### DIFF
--- a/lib/dapp/dimg/build/stage/ga_artifact_patch.rb
+++ b/lib/dapp/dimg/build/stage/ga_artifact_patch.rb
@@ -8,6 +8,10 @@ module Dapp
             super
           end
 
+          def empty?
+            dimg.git_artifacts.empty? || dependencies_empty?
+          end
+
           def dependencies
             dimg.stage_by_name(:build_artifact).context
           end


### PR DESCRIPTION
* в отличие от GALatestPatch, базового класса GAArtifactPatch, стадия не должна зависить от наличия изменений в git-репозиториях.