### PR TITLE
Возможность создавать symlink'и в артефактах

### DIFF
--- a/lib/dapp/version.rb
+++ b/lib/dapp/version.rb
@@ -1,5 +1,5 @@
 # Version
 module Dapp
   VERSION = '0.7.28'.freeze
-  BUILD_CACHE_VERSION = 6
+  BUILD_CACHE_VERSION = '6.1'
 end


### PR DESCRIPTION
Переделан механизм копирования файлов артефакта на использование rsync.
    
* Symlink'и копируются "как есть", чтобы они работали в директории назначения — надо использовать относительные пути.
* Убрано ограничение на спец. символы в именах файлов в артефакте.
* Теоретически повышена производительность для больших артефактов (не проверено).