### PR TITLE
Исправлена ошибка при использовании docker 17.04.0 (backport из 0.10)

### DIFF
--- a/config/en/net_status.yml
+++ b/config/en/net_status.yml
@@ -17,6 +17,7 @@ en:
       image_not_exist: "Image `%{name}` not exist!"
       built_id_not_defined: '`from.built_id` not defined!'
       from_image_not_found: 'Image `%{name}` not found!'
+      unsupported_docker_image_size_format: "Unsupported docker image size format `%{value}`"
     project:
       command_unexpected_dimgs_number: "Command can process only one dimg!\nAmbiguous dimg pattern: `%{dimgs_names}`!"
       no_such_dimg: "No such dimg: `%{dimgs_patterns}`!"

--- a/lib/dapp/image/docker.rb
+++ b/lib/dapp/image/docker.rb
@@ -90,17 +90,23 @@ module Dapp
         def cache_reset(name = '')
           cache.delete(name)
           Project.shellout!("docker images --format='{{.Repository}}:{{.Tag}};{{.ID}};{{.CreatedAt}};{{.Size}}' --no-trunc #{name}").stdout.lines.each do |l|
-            name, id, created_at, size_field = l.split(';')
+            name, id, created_at, size_field = l.split(';').map(&:strip)
             size = begin
-              number, unit = size_field.split
-              coef = case unit.to_s.downcase
-                     when 'b'  then return number.to_f
+              match = size_field.match(/^(\d+(\.\d+)?)\ ?(b|kb|mb|gb|tb)$/i)
+              raise Error::Build, code: :unsupported_docker_image_size_format, data: {value: size_field} unless match and match[1] and match[3]
+
+              number = match[1].to_f
+              unit = match[3].downcase
+
+              coef = case unit
+                     when 'b'  then 0
                      when 'kb' then 1
                      when 'mb' then 2
                      when 'gb' then 3
                      when 'tb' then 4
                      end
-              number.to_f * (1000 ** coef)
+
+              number * (1000**coef)
             end
             cache[name] = { id: id, created_at: created_at, size: size }
           end


### PR DESCRIPTION
Поменялся формат поля Size для образов — убрали пробел
* Переделан парсер
* Исправлен баг в методе сброса кеша
  * Использование return внутри begin..end не дает ожидаемого результата, а выбрасывает из метода.
  * Баг с неполным заполнением кеша мог проявляться, если в системе существует хотя бы один образ с размером меньше килобайта.
