### PR TITLE
22: Изменена директива expose.port

### DIFF
--- a/config/en/net_status.yml
+++ b/config/en/net_status.yml
@@ -70,7 +70,8 @@ en:
       app_bootstrap_dimg_not_found: "Not found dimg `%{dimg}` for app.bootstrap!"
       app_before_apply_job_dimg_not_defined: "Not defined dimg for app.before_apply_job!"
       app_before_apply_job_dimg_not_found: "Not found dimg `%{dimg}` for app.before_apply_job!"
-      unsupported_port_number: 'Port number `%{port}` doesn`t support!'
+      unsupported_port_number: 'Port number `%{number}` doesn`t support!'
+      unsupported_target_number: 'Target number `%{number}` doesn`t support!'
       app_name_incorrect: "App has incorrect name `%{value}`: doesn't match regex `%{pattern}`!"
       namespace_name_incorrect: "Namespace has incorrect name `%{value}`: doesn't match regex `%{pattern}`!"
       deployment_bootstrap_dimg_not_defined: "Not defined dimg for deployment.bootstrap!"

--- a/lib/dapp/deployment/app.rb
+++ b/lib/dapp/deployment/app.rb
@@ -50,11 +50,13 @@ module Dapp
                     container['imagePullPolicy'] = 'Always'
                     container['image']           = [repo, [dimg, image_version].compact.join('-')].join(':')
                     container['name']            = dimg_name
-                    container['ports']           = expose._port.map do |p|
-                      p._list.each_with_index.map do |port, ind|
-                        { "containerPort" => port, 'name' => ['app', ind].join('-'), "protocol" => p._protocol }
-                      end
-                    end.flatten
+                    container['ports']           = expose._port.map do |port|
+                      {
+                        "containerPort" => port._number,
+                        'name' => ['app', port._number].join('-'),
+                        "protocol" => port._protocol
+                      }
+                    end
                   end
                 end
               end
@@ -74,11 +76,15 @@ module Dapp
             end
             service['spec'] = {}.tap do |spec|
               spec['selector'] = kube.labels
-              spec['ports']    = expose._port.map do |p|
-                p._list.each_with_index.map do |port, ind|
-                  { 'port' => port, 'name' => ['service', ind].join('-'), 'protocol' => p._protocol }
+              spec['ports']    = expose._port.map do |port|
+                {
+                  'port' => port._number,
+                  'name' => ['service', port._number].join('-'),
+                  'protocol' => port._protocol
+                }.tap do |h|
+                  h['targetPort'] = port._target unless port._target.nil?
                 end
-              end.flatten
+              end
             end
           end
         end

--- a/lib/dapp/deployment/config/directive/expose.rb
+++ b/lib/dapp/deployment/config/directive/expose.rb
@@ -14,17 +14,21 @@ module Dapp
             sub_directive_eval { @_cluster_ip = true }
           end
 
-          def port(*args, &blk)
-            sub_directive_eval { @_port << Port.new(*args, dapp: dapp, &blk) }
+          def port(number, &blk)
+            sub_directive_eval { @_port << Port.new(number, dapp: dapp, &blk) }
           end
 
           class Port < Base
-            attr_reader :_list, :_protocol
+            attr_reader :_number, :_target, :_protocol
 
-            def initialize(*args, dapp:, &blk)
-              self._list = args
+            def initialize(number, dapp:, &blk)
+              self._number = number
               @_protocol = 'TCP'
               super(dapp: dapp, &blk)
+            end
+
+            def target(number)
+              @_target = define_number(number, :unsupported_target_number)
             end
 
             def tcp
@@ -35,13 +39,15 @@ module Dapp
               @_protocol = 'UDP'
             end
 
-            def _list=(ports)
-              @_list = begin
-                ports.map do |port|
-                  port.to_i.tap do |p|
-                    raise Error::Config, code: :unsupported_port_number, data: { port: port } unless (0..65536).cover?(p)
-                  end
-                end
+            def _number=(number)
+              @_number = define_number(number, :unsupported_port_number)
+            end
+
+            protected
+
+            def define_number(number, code)
+              number.to_i.tap do |n|
+                raise Error::Config, code: code, data: { number: number } unless (0..65536).cover?(n)
               end
             end
           end

--- a/spec/unit/config/deployment/expose_spec.rb
+++ b/spec/unit/config/deployment/expose_spec.rb
@@ -34,10 +34,14 @@ describe Dapp::Deployment::Config::Directive::Expose do
 
     context 'positive' do
       it 'definition' do
-        values = [80, 8080]
-        dappfile_app_expose_port(*values)
+        dappfile_app_expose_port(80)
         expect(app_config._expose._port.length).to be 1
-        expect(app_config._expose._port.first._list).to eq values
+        expect(app_config._expose._port.first._number).to eq 80
+      end
+
+      it 'target port' do
+        dappfile_app_expose_port(80) { target 8080 }
+        expect(app_config._expose._port.first._target).to eq 8080
       end
 
       it 'default protocol' do
@@ -61,6 +65,11 @@ describe Dapp::Deployment::Config::Directive::Expose do
         it "unsupported port value `#{incorrect_value}` (:unsupported_port_number)" do
           dappfile_app_expose_port(incorrect_value)
           expect_exception_code(:unsupported_port_number) { config }
+        end
+
+        it "unsupported target value `#{incorrect_value}` (:unsupported_target_number)" do
+          dappfile_app_expose_port(80) { target incorrect_value }
+          expect_exception_code(:unsupported_target_number) { config }
         end
       end
     end

--- a/spec/unit/config/deployment/group_spec.rb
+++ b/spec/unit/config/deployment/group_spec.rb
@@ -126,7 +126,7 @@ describe Dapp::Deployment::Config::Directive::Group do
           app
         end
         expect(app_config._expose._cluster_ip).to be_falsey
-        expect(app_config._expose._port.first._list).to eq([80])
+        expect(app_config._expose._port.first._number).to eq(80)
         expect(app_config._expose._port.first._protocol).to eq('UDP')
       end
 


### PR DESCRIPTION
* в качестве параметре принимается единственный порт;
* добавлена необязательная поддиректива `target`.