### PR TITLE
27: Возможность менять NodePort на ClusterIP для Service и рефакторинг kubernetes клиента

### DIFF
--- a/lib/dapp/deployment/kube_app.rb
+++ b/lib/dapp/deployment/kube_app.rb
@@ -245,11 +245,13 @@ module Dapp
 
       def merge_kube_service_spec(spec1, spec2)
         spec1.kube_in_depth_merge(spec2).tap do |spec|
+          spec['metadata'] ||= {}
+          metadata_labels = spec2.fetch('metadata', {}).fetch('labels', nil)
+          spec['metadata']['labels'] = metadata_labels if metadata_labels
+
           spec['spec'] ||= {}
-
-          spec_selector = spec2.fetch('spec', spec1.fetch('spec', {})).fetch('selector', nil)
+          spec_selector = spec2.fetch('spec', {}).fetch('selector', nil)
           spec['spec']['selector'] = spec_selector if spec_selector
-
           spec['spec']['ports'] = begin
             ports1 = spec1.fetch('spec', {}).fetch('ports', [])
             ports2 = spec2.fetch('spec', {}).fetch('ports', [])


### PR DESCRIPTION
* При смене NodePort или LoadBalancer на ClusterIP в spec ресурса оставалось старое поле nodePort
  * Это поле устанавливает сам kubernetes для NodePort или LoadBalancer
  * А когда меняется type на ClusterIP — kubernetes ругается на наличие этого поля в replace-операции
  * Сделано ручное удаление специально для данной ситуации
* Замена labels и selector при обновлении Service
  * Когда обновляется kubernetes Service те metadata.labels и spec.selector, которые были указаны в текущей версии объекта перетираются значениями, соответсвующими текущей конфигурации из Dappfile.
* Рефакторинг kubernetes клиента
  * Данные для ошибок
    * Попытка распарсить json когда возможно
    * Если не получается распарсить — в ошибке будет http body
  * Это сделано, чтобы ошибки стали более читаемыми
    * Пользовательские ошибки в Dappfile сейчас могут быть сообщены через ошибки клиента kubernetes
      * Например, если продублировать один и тот же порт для expose