### PR TITLE
28: Авто-том /.data монтируется во все Pod'ы app, ожидание Deployment при изм. replicas исправлено

### DIFF
--- a/lib/dapp/deployment/app.rb
+++ b/lib/dapp/deployment/app.rb
@@ -53,14 +53,23 @@ module Dapp
                         'protocol' => port._protocol
                       }
                     end
+                    volume_mounts = [{'mountPath' => '/.data', 'name' => "volume-#{self.name}"}]
 
                     container['imagePullPolicy'] = 'Always'
                     container['image']           = [repo, [dimg, image_version].compact.join('-')].join(':')
                     container['name']            = dimg_name
                     container['env']             = envs unless envs.empty?
                     container['ports']           = ports unless expose._port.empty?
+                    container['volumeMounts']    = volume_mounts
                   end
                 end
+
+                template_spec['volumes'] = [
+                  {
+                    'name' => "volume-#{name}",
+                    'hostPath' => {'path' => "/var/lib/dapp/deployment/volumes/#{self.deployment.name}/#{self.name}"}
+                  }
+                ]
               end
             end
           end


### PR DESCRIPTION
### Авто-том /.data монтируется во все Pod'ы app

Авто монтирование директории узла `/var/lib/dapp/deployment/volumes/<dapp-name>/<app-name>` в директорию `/.data` всех контейнеров всех Pod'ов одного app из Dappfile (через kubernetes  hostPath).

Сделано для непредусмотренных ситуаций, когда очень нужна возможность хранения данных.

### Ожидание Deployment при изм. replicas исправлено

Фикс критерия ожидания выката kube Deployment по полю `deployment.kubernetes.io/revision`. Ранее ожидалась смена этой ревизии. Но это не работает при изменении кол-ва replicas — ревизия остается старой.
    
На данный момент используется следующий костыль:
* При обновлении ревизия сбрасывается.
* Ожидается переустановка этого поля.
* При этом значение ревизии может остаться старым, важен лишь факт ее появления у ресурса.