### PR TITLE
Исправление нерабочего include_paths для артефактов

### DIFF
--- a/lib/dapp/dimg/build/stage/artifact_default.rb
+++ b/lib/dapp/dimg/build/stage/artifact_default.rb
@@ -46,12 +46,19 @@ module Dapp
                 end
 
                 include_paths.each do |p|
+                  target_path = File.join(from, p)
+
+                  # Генерируем разрешающее правило для каждого элемента пути
+                  Pathname.new(target_path).descend do |path_part|
+                    cmd << " --filter='+/ #{path_part}'"
+                  end
+
                   # * На данный момент не знаем директорию или файл имел в виду пользователь,
                   #   поэтому подставляем фильтры для обоих возможных случаев.
                   # * Автоматом подставляем паттерн ** для включения файлов, содержащихся в
                   #   директории, которую пользователь указал в include_paths.
-                  cmd << " --filter='+/ #{File.join(from, p)}'"
-                  cmd << " --filter='+/ #{File.join(from, p, '**')}'"
+                  cmd << " --filter='+/ #{target_path}'"
+                  cmd << " --filter='+/ #{File.join(target_path, '**')}'"
                 end
 
                 # Все что не подошло по include — исключается

--- a/lib/dapp/version.rb
+++ b/lib/dapp/version.rb
@@ -1,4 +1,4 @@
 module Dapp
-  VERSION = '0.12.5'.freeze
-  BUILD_CACHE_VERSION = 11
+  VERSION = '0.12.6'.freeze
+  BUILD_CACHE_VERSION = 12
 end


### PR DESCRIPTION
Логическая ошибка в указании параметов в rsync: надо указывать позитивные фильтры для всех элементов каждого пути из include_paths.