### PR TITLE
Экспорт файлов артефакта без изменения owner/group

### DIFF
--- a/lib/dapp/build/stage/artifact_default.rb
+++ b/lib/dapp/build/stage/artifact_default.rb
@@ -18,7 +18,7 @@ module Dapp
           group = artifact[:options][:group]
           to = artifact[:options][:to]
 
-          command = safe_cp(cwd, artifact_dimg.container_tmp_path(artifact_name).to_s, Process.uid, Process.gid, include_paths, exclude_paths)
+          command = safe_cp(cwd, artifact_dimg.container_tmp_path(artifact_name).to_s, nil, nil, include_paths, exclude_paths)
           run_artifact_dimg(artifact_dimg, artifact_name, command)
 
           command = safe_cp(dimg.container_tmp_path('artifact', artifact_name).to_s, to, owner, group, include_paths, exclude_paths)

--- a/lib/dapp/dimg/path.rb
+++ b/lib/dapp/dimg/path.rb
@@ -11,8 +11,12 @@ module Dapp
         make_path(project.local_cookbook_path, *path)
       end
 
+      def tmp_base_dir
+        File.expand_path(project.cli_options[:tmp_dir_prefix] || '/tmp')
+      end
+
       def tmp_path(*path)
-        @tmp_path ||= Dir.mktmpdir('dapp-', project.cli_options[:tmp_dir_prefix] || '/tmp')
+        @tmp_path ||= Dir.mktmpdir('dapp-', tmp_base_dir)
         make_path(@tmp_path, *path).expand_path.tap { |p| p.parent.mkpath }
       end
 

--- a/lib/dapp/version.rb
+++ b/lib/dapp/version.rb
@@ -1,5 +1,5 @@
 # Version
 module Dapp
   VERSION = '0.7.35'.freeze
-  BUILD_CACHE_VERSION = '6.4'
+  BUILD_CACHE_VERSION = '6.5'
 end

--- a/spec/chef/testproject/.dapp_chef/recipes/build_artifact/myartifact.rb
+++ b/spec/chef/testproject/.dapp_chef/recipes/build_artifact/myartifact.rb
@@ -1,13 +1,13 @@
 directory '/myartifact' do
-  owner 'root'
-  group 'root'
+  owner 'www-data'
+  group 'www-data'
   mode '0755'
   action :create
 end
 
 file "/myartifact/#{node.read('mdapp-testartifact', 'target_filename')}" do
-  owner 'root'
-  group 'root'
+  owner 'www-data'
+  group 'www-data'
   mode '0777'
   content ::File.open("/testartifact/#{node.read('mdapp-testartifact', 'target_filename')}").read
   action :create


### PR DESCRIPTION
Те owner/group, которые были проставлены при создании файлов артефакта будут использованы и при импорте артефакта в образ в случае если owner и group не указаны явно в Dappfile.

Очистка tmp-dir сделана через docker-контейнер под пользователем root, т.к. в этой директории могут быть произвольные владельцы и права после копирования файлов из артефакта.