### PR TITLE
Экспорт файлов артефакта без изменения owner/group

### DIFF
--- a/lib/dapp/dimg/build/stage/artifact_default.rb
+++ b/lib/dapp/dimg/build/stage/artifact_default.rb
@@ -17,7 +17,7 @@ module Dapp
             group = artifact[:options][:group]
             to = artifact[:options][:to]
 
-            command = safe_cp(cwd, artifact_dimg.container_tmp_path(artifact_name).to_s, Process.uid, Process.gid, include_paths, exclude_paths)
+            command = safe_cp(cwd, artifact_dimg.container_tmp_path(artifact_name).to_s, nil, nil, include_paths, exclude_paths)
             run_artifact_dimg(artifact_dimg, artifact_name, command)
 
             command = safe_cp(dimg.container_tmp_path('artifact', artifact_name).to_s, to, owner, group, include_paths, exclude_paths)

--- a/lib/dapp/dimg/dimg.rb
+++ b/lib/dapp/dimg/dimg.rb
@@ -163,7 +163,18 @@ module Dapp
       end
 
       def cleanup_tmp
-        FileUtils.rm_rf(tmp_path)
+        # В tmp-директории могли остаться файлы, владельцами которых мы не являемся.
+        # Такие файлы могут попасть туда при экспорте файлов артефакта.
+        # Чтобы от них избавиться — запускаем docker-контейнер под root-пользователем
+        # и удаляем примонтированную tmp-директорию.
+        cmd = "".tap do |cmd|
+          cmd << "docker run --rm"
+          cmd << " --volume #{tmp_base_dir}:#{tmp_base_dir}"
+          cmd << " ubuntu:16.04"
+          cmd << " rm -rf #{tmp_path}"
+        end
+        dapp.shellout! cmd
+
         artifacts.each(&:cleanup_tmp)
       end
 

--- a/lib/dapp/dimg/dimg/path.rb
+++ b/lib/dapp/dimg/dimg/path.rb
@@ -6,8 +6,12 @@ module Dapp
           make_path(dapp.path, *path).expand_path
         end
 
+        def tmp_base_dir
+          File.expand_path(dapp.options[:tmp_dir_prefix] || '/tmp')
+        end
+
         def tmp_path(*path)
-          @tmp_path ||= Dir.mktmpdir('dapp-', dapp.options[:tmp_dir_prefix] || '/tmp')
+          @tmp_path ||= Dir.mktmpdir('dapp-', tmp_base_dir)
           make_path(@tmp_path, *path).expand_path.tap { |p| p.parent.mkpath }
         end
 

--- a/lib/dapp/version.rb
+++ b/lib/dapp/version.rb
@@ -1,4 +1,4 @@
 module Dapp
   VERSION = '0.12.6'.freeze
-  BUILD_CACHE_VERSION = 12
+  BUILD_CACHE_VERSION = 13
 end

--- a/spec/chef/testproject/.dapp_chef/recipes/build_artifact/myartifact.rb
+++ b/spec/chef/testproject/.dapp_chef/recipes/build_artifact/myartifact.rb
@@ -1,13 +1,13 @@
 directory '/myartifact_testproject' do
-  owner 'root'
-  group 'root'
+  owner 'www-data'
+  group 'www-data'
   mode '0755'
   action :create
 end
 
 file "/myartifact_testproject/#{node.read('dimod-testartifact', 'target_filename')}" do
-  owner 'root'
-  group 'root'
+  owner 'www-data'
+  group 'www-data'
   mode '0777'
   content ::File.open("/testartifact/#{node.read('dimod-testartifact', 'target_filename')}").read
   action :create


### PR DESCRIPTION
Те owner/group, которые были проставлены при создании файлов артефакта будут использованы и при импорте артефакта в образ в случае если owner и group не указаны явно в Dappfile.

Очистка tmp-dir сделана через docker-контейнер под пользователем root, т.к. в этой директории могут быть произвольные владельцы и права после копирования файлов из артефакта.

Refs #244