### PR TITLE
Фикс протокола записи секретов в файлы; безопасные права доступа к расшифрованым секретам

### DIFF
--- a/lib/dapp/kube/dapp/command/deploy.rb
+++ b/lib/dapp/kube/dapp/command/deploy.rb
@@ -77,7 +77,7 @@ module Dapp
             Dir.glob(kube_chart_secret_path.join('**/*')).each do |entry|
               next unless File.file?(entry)
               secret_relative_path = Pathname(entry).subpath_of(kube_chart_secret_path)
-              IO.binwrite(kube_tmp_chart_secret_path(secret_relative_path), secret.extract(IO.binread(entry)))
+              IO.binwrite(kube_tmp_chart_secret_path(secret_relative_path), secret.extract(IO.binread(entry).chomp("\n")))
             end
           end
 

--- a/lib/dapp/kube/dapp/command/secret_file_encrypt.rb
+++ b/lib/dapp/kube/dapp/command/secret_file_encrypt.rb
@@ -12,7 +12,7 @@ module Dapp
               puts encrypted_data
             else
               FileUtils.mkpath File.dirname(output_file_path)
-              IO.binwrite(output_file_path, encrypted_data)
+              IO.binwrite(output_file_path, "#{encrypted_data}\n")
             end
           end
         end


### PR DESCRIPTION
## Фикс протокола записи секретов в файлы

Если используется команда `dapp kube secret file encrypt` без параметра `-o`, то зашифрованные данные пишутся на stdout. Скопировав их оттуда и вставив в редактор в конце будет вставлен перенос строки в половине существующих тектовых редакторов. Также перенос строки будет вставлен в файл output и при использовании такой записи: `dapp kube secret file encrypt mysecret > output`.

Недоработка была в том, что при чтении секрета из файла хвостовой перенос строки не отрезался.

При этом при использовании параметра `-o` хвостовой перенос строки не вставлялся и поэтому с этим параметром все работало.

Переделано так, что при использовании параметра `-o` обязательно вставляется хвостовой перенос строки. И этот перенос строки отрезается при расшифровке файла.

## Безопасные права доступа к расшифрованым секретам

* Права только на чтение только владельцем: 0400.
* Также убрана возможность не удалять tmp-helm-chart, чтобы в системе не оставались расшифрованые секреты.
  * По большому счету там смотреть пользователю не на что, кроме расшифрованых секретов и сгенеренных helper-ов для template-ов.
* Префикс директории chart'а изменен на dapp-helm-chart-RANDOM.
