### PR TITLE
Исправление ошибки при запуске сборки chef-проекта без git-репо

### DIFF
--- a/lib/dapp/dapp.rb
+++ b/lib/dapp/dapp.rb
@@ -37,9 +37,9 @@ module Dapp
           repo_name = repo_name[/.*(?=\.git)/] if repo_name.end_with? '.git'
           repo_name
         elsif git_path
-          File.basename(File.dirname(git_path))
+          File.basename(File.dirname(git_path)).to_s
         else
-          path.basename
+          path.basename.to_s
         end
       end
     end


### PR DESCRIPTION
Имя проекта определяется как имя директории, содержащей Dappfile. В этом случае Dapp::name возвращал Pathname вместо строки.