### PR TITLE
Обработка ошибок запросов на получение логов контейнеров

### DIFF
--- a/lib/dapp/kube/kubernetes/client/error.rb
+++ b/lib/dapp/kube/kubernetes/client/error.rb
@@ -19,6 +19,11 @@ module Dapp
 
       module Pod
         class NotFound < Kubernetes::Client::Error::NotFound ; end
+        class ContainerCreating < Kubernetes::Client::Error::Base
+          def initialize(**net_status)
+            super({code: :container_creating}.merge(net_status))
+          end
+        end
       end # Pod
     end # Kubernetes::Client::Error
   end # Kube

--- a/lib/dapp/kube/kubernetes/manager/job.rb
+++ b/lib/dapp/kube/kubernetes/manager/job.rb
@@ -40,7 +40,7 @@ module Dapp
               if job.succeeded?
                 break
               elsif job.failed?
-                warn "Job '#{name}' has been failed: #{job.spec['status']}"
+                dapp.log_warning "Job '#{name}' has been failed: #{job.spec['status']}"
                 break
               end
 
@@ -53,7 +53,7 @@ module Dapp
             begin
               pod_manager.watch_till_done!
             rescue Kubernetes::Client::Error::Pod::NotFound => err
-              warn "Pod '#{err.net_status.fetch(:response_body, {}).fetch('details', {})['name']}' has been deleted"
+              dapp.log_warning "Pod '#{pod_manager.name}' has been deleted"
             ensure
               @processed_pods_names << process_pod.name
             end


### PR DESCRIPTION
Любой запрос на получение лога контейнера в pod'е может упасть с ошибкой, если контейнер еще не запущен. Даже если перед запросом логов проверить состояние контейнера — это не гарантирует, что контейнер не будет остановлен прямо перед запросом логов.