### PR TITLE
Принудительный выход из потока для dapp/watch-logs

### DIFF
--- a/lib/dapp/kube/dapp/command/deploy.rb
+++ b/lib/dapp/kube/dapp/command/deploy.rb
@@ -155,13 +155,13 @@ module Dapp
 
               deployment_managers.each(&:after_deploy)
 
+              watch_hooks_thr.kill if watch_hooks_thr.alive?
+
               begin
                 ::Timeout::timeout(self.options[:timeout] || 300) do
-                  watch_hooks_thr.join
                   deployment_managers.each {|deployment_manager| deployment_manager.watch_till_ready!}
                 end
               rescue ::Timeout::Error
-                watch_hooks_thr.kill if watch_hooks_thr.alive?
                 raise Error::Base, code: :deploy_timeout
               end
             end


### PR DESCRIPTION
После завершения работы helm хуки должны быть выполнены, следовательно и поток для вывода логов должен завершиться.
Но в коде вывода логов вероятно есть баг, который блокирует выход этого потока.
Как защита от этого на данный момент поток вывода логов принудительно завершается после выхода helm.