### PR TITLE
Revert "Фикс stage_dependencies для пересборки стадий install,setup"

### DIFF
--- a/lib/dapp/dimg/build/stage/ga_related_dependencies_base.rb
+++ b/lib/dapp/dimg/build/stage/ga_related_dependencies_base.rb
@@ -8,7 +8,7 @@ module Dapp
           end
 
           def empty?
-            dimg.stage_by_name(related_stage_name).empty? && super
+            dimg.stage_by_name(related_stage_name).empty? || super
           end
 
           def related_stage_name


### PR DESCRIPTION
Раньше если стадия пустая, то изменение файлов из stage_dependecies для этой стадии ни на что не влияло. Теперь, если указать stage_dependencies для стадии, то она начнет собираться и пересобираться при изменении указанных файлов, но т.к. в ней нет инструкций -- это лишнее действие.
