### PR TITLE
Фикс проблемы с созданием git-архива + --use-system-tar (permission denied)

### DIFF
--- a/lib/dapp/helper/trivia.rb
+++ b/lib/dapp/helper/trivia.rb
@@ -25,7 +25,7 @@ module Dapp
       end
 
       def make_path(base, *path)
-        path.compact.map(&:to_s).inject(Pathname.new(base), &:+)
+       Pathname.new(File.join(base.to_s, path.compact.map(&:to_s)))
       end
 
       def self.class_to_lowercase(class_name = self)


### PR DESCRIPTION
При исползовании опции --use-system-tar git-архив создавался без использования временной директории, а прямо в корне системы, где запущен dapp. Если dapp был запущен под root — все работало "незаметно", если не root — был permission denied.

Вывод: никогда не использовать `Pathname::+` и `Pathname::join`, а использовать только `File.join`.