### PR TITLE
Пересборка невалидных стадий во время сборки

### DIFF
--- a/config/en/common.yml
+++ b/config/en/common.yml
@@ -38,6 +38,7 @@ en:
     state:
       using_cache: '[USING CACHE]'
       not_present: '[NOT PRESENT]'
+      rebuild: '[REBUILD]'
       build: '[BUILD]'
       push: '[PUSH]'
       pull: '[PULL]'

--- a/lib/dapp/dimg/build/stage/ga_base.rb
+++ b/lib/dapp/dimg/build/stage/ga_base.rb
@@ -35,6 +35,11 @@ module Dapp
             end
           end
 
+          def renew
+            @commits = {}
+            super
+          end
+
           protected
 
           def should_not_be_detailed?

--- a/lib/dapp/dimg/build/stage/ga_dependencies_base.rb
+++ b/lib/dapp/dimg/build/stage/ga_dependencies_base.rb
@@ -14,6 +14,13 @@ module Dapp
           def empty?
             dimg.git_artifacts.empty? || super
           end
+
+          def image_should_be_untagged_condition
+            return false unless image.tagged?
+            dimg.git_artifacts.any? do |git_artifact|
+              !git_artifact.repo.commit_exists? image.labels["dapp-git-#{git_artifact.paramshash}-commit"]
+            end
+          end
         end # GADependenciesBase
       end # Stage
     end # Build

--- a/lib/dapp/dimg/build/stage/import_artifact.rb
+++ b/lib/dapp/dimg/build/stage/import_artifact.rb
@@ -8,7 +8,7 @@ module Dapp
           end
 
           def signature
-            @signature ||= hashsum [*dependencies.flatten, change_options]
+            hashsum [*dependencies.flatten, change_options]
           end
 
           def image

--- a/lib/dapp/dimg/build/stage/mod/logging.rb
+++ b/lib/dapp/dimg/build/stage/mod/logging.rb
@@ -6,9 +6,10 @@ module Dapp
           module Logging
             def log_image_build
               case
-              when image.built?           then log_state(:using_cache)
-              when should_be_not_present? then log_state(:not_present)
-              when dimg.dapp.dry_run?     then log_state(:build, styles: { status: :success })
+              when dimg.dapp.dry_run? && image_should_be_untagged? then log_state(:rebuild, styles: { status: :success })
+              when image.built?                                    then log_state(:using_cache)
+              when should_be_not_present?                          then log_state(:not_present)
+              when dimg.dapp.dry_run?                              then log_state(:build, styles: { status: :success })
               else yield
               end
             ensure

--- a/lib/dapp/dimg/build/stage/setup/ga_post_setup_patch_dependencies.rb
+++ b/lib/dapp/dimg/build/stage/setup/ga_post_setup_patch_dependencies.rb
@@ -21,7 +21,11 @@ module Dapp
 
             def changes_size_since_g_a_pre_setup_patch
               dimg.git_artifacts.map do |git_artifact|
-                git_artifact.patch_size(prev_g_a_stage.layer_commit(git_artifact), git_artifact.latest_commit)
+                if git_artifact.repo.commit_exists? prev_g_a_stage.layer_commit(git_artifact)
+                  git_artifact.patch_size(prev_g_a_stage.layer_commit(git_artifact), git_artifact.latest_commit)
+                else
+                  0
+                end
               end.reduce(0, :+)
             end
           end # GAPostSetupPatchDependencies

--- a/lib/dapp/dimg/image/docker.rb
+++ b/lib/dapp/dimg/image/docker.rb
@@ -6,8 +6,18 @@ module Dapp
         attr_reader :name
         attr_reader :dapp
 
-        def self.image_by_name(name:, **kwargs)
-          (@images ||= {})[name] ||= new(name: name, **kwargs)
+        class << self
+          def image_by_name(name:, **kwargs)
+            images[name] ||= new(name: name, **kwargs)
+          end
+
+          def image_reset(name)
+            images.delete(name)
+          end
+
+          def images
+            @images ||= {}
+          end
         end
 
         def initialize(name:, dapp:, from: nil)


### PR DESCRIPTION
На текущий момент пересборка необходима в тех случаях, когда в лейблах образов кеша содержатся несуществующие комиты (rebase).

> Зачем делать image_reset для всех последующих образов?
* После того, как стадия была пересобрана, необходимо актуализировать закешированные данные в связанных стадиях:
  * Сбросить образ из кеша `Image::Stage.images` (никак не связан с образами хранящимися в docker, `Image::Stage.cache`). Таким образом, обновив from, пересобранным образом. 
  * Сбросить dependencies. В случае, если зависимости основываются на комитах (актуально для `setup/ga_post_setup_patch_dependencies` при подсчёте размеров патчей, и последующих стадий, так как изменяется сигнатура).

  * Сбросить закешированные git-комиты для git-стадий.

> Зачем делать image_untag для всех последующих собранных образов?

* Так как они основаны на невалидном кеше.

> Костыль в setup/ga_post_setup_patch_dependencies?

* Для вычисления сигнатуры необходимо подсчитать размер патча между комитом предыдущей git-стадии и HEAD. В случае, если предыдущая git-стадия содержит несуществующие комиты предлагается:
  * Считать размер патча с несуществующим комитом равным нулю.
  * После пересборки связанной git-стадиии пересчитывать с актуальными данными.