### PR TITLE
Ускорение работы внутреннего кеша образов сборщика dimg

### DIFF
--- a/lib/dapp/dapp/shellout/base.rb
+++ b/lib/dapp/dapp/shellout/base.rb
@@ -50,6 +50,12 @@ module Dapp
           end
         end # << self
 
+        def shellout_cmd_should_succeed!(cmd)
+          return cmd.tap(&:error!)
+        rescue ::Mixlib::ShellOut::ShellCommandFailed => e
+          raise Error::Shellout, code: Helper::Trivia.class_to_lowercase(e.class), data: { stream: e.message }
+        end
+
         protected
 
         def _shellout_with_logging!(*args, verbose: false, quiet: true, time: false, **kwargs)

--- a/lib/dapp/dimg/build/stage/base.rb
+++ b/lib/dapp/dimg/build/stage/base.rb
@@ -27,7 +27,7 @@ module Dapp
               no_lock = false
 
               dimg.dapp.lock("#{dimg.dapp.name}.image.#{image.name}") do
-                image.cache_reset
+                image.class.reset_image_inspect(image.name)
 
                 if image_should_be_locked?
                   yield

--- a/lib/dapp/dimg/dimg.rb
+++ b/lib/dapp/dimg/dimg.rb
@@ -83,7 +83,8 @@ module Dapp
           dapp.log_state(image_name, state: dapp.t(code: 'state.push'), styles: { status: :success })
         else
           dapp.lock("image.#{hashsum image_name}") do
-            ::Dapp::Dimg::Image::Stage.cache.delete(image_name)
+            ::Dapp::Dimg::Image::Docker.reset_image_inspect(image_name)
+
             dapp.log_process(image_name, process: dapp.t(code: 'status.process.pushing')) do
               image.export!(image_name)
             end


### PR DESCRIPTION
Использование `docker inspect` вместо `docker images`.