### PR TITLE
dapp kube render command: добавлена опция `--template GLOB_PATTERN`

### DIFF
--- a/lib/dapp/kube/cli/command/kube/render.rb
+++ b/lib/dapp/kube/cli/command/kube/render.rb
@@ -35,6 +35,12 @@ BANNER
              default: [],
              proc: proc { |v| composite_options(:helm_secret_values) << v }
 
+      option :templates,
+             long: '--template GLOB_PATTERN',
+             short: '-t GLOB_PATTERN',
+             default: [],
+             proc: proc { |v| composite_options(:templates) << v }
+
       def run(argv = ARGV)
         self.class.parse_options(self, argv)
 

--- a/lib/dapp/kube/dapp/command/render.rb
+++ b/lib/dapp/kube/dapp/command/render.rb
@@ -4,7 +4,23 @@ module Dapp
       module Command
         module Render
           def kube_render
-            helm_release { |release| release.templates.values.each { |t| puts t } }
+            helm_release do |release|
+              templates = begin
+                if options[:templates].any?
+                  release.templates.select do |template_path, _|
+                    options[:templates].map { |t| "#{t}*" }.any? do |template_path_pattern|
+                      template_relative_path_pattern = Pathname(File.expand_path(template_path_pattern)).subpath_of(path('.helm', 'templates'))
+                      template_relative_path_pattern ||= template_path_pattern
+                      File.fnmatch(template_relative_path_pattern, template_path)
+                    end
+                  end
+                else
+                  release.templates
+                end
+              end
+
+              templates.values.each { |t| puts t }
+            end
           end
         end
       end


### PR DESCRIPTION
* позволяет вывести определённую группу спеков;
* в качестве параметра указывается шаблон пути (`-t .helm/templates/*_custom`) или имени спека (`-t *_custom`).
* ко всем шаблонам в конец добавляется `*`.