### PR TITLE
dapp kube render command: изменена логика

### DIFF
--- a/lib/dapp/kube/dapp/command/render.rb
+++ b/lib/dapp/kube/dapp/command/render.rb
@@ -9,9 +9,12 @@ module Dapp
                 if options[:templates].any?
                   release.templates.select do |template_path, _|
                     options[:templates].map { |t| "#{t}*" }.any? do |template_path_pattern|
-                      template_relative_path_pattern = Pathname(File.expand_path(template_path_pattern)).subpath_of(path('.helm', 'templates'))
+                      template_path_without_chart_name = template_path[/.*?\/(.*)/, 1]
+                      template_relative_path_pattern = Pathname(File.expand_path(template_path_pattern)).subpath_of(path('.helm'))
                       template_relative_path_pattern ||= template_path_pattern
-                      File.fnmatch(template_relative_path_pattern, template_path)
+
+                      File.fnmatch(template_relative_path_pattern, template_path_without_chart_name) ||
+                        File.fnmatch(template_relative_path_pattern, template_path)
                     end
                   end
                 else

--- a/lib/dapp/kube/helm/release.rb
+++ b/lib/dapp/kube/helm/release.rb
@@ -63,7 +63,7 @@ module Dapp
           current_template = nil
           spec = 0
           evaluation_output.lines.each do |l|
-            if (match = l[/# Source: #{dapp.name}\/templates\/(.*)/, 1])
+            if (match = l[/# Source: (.*)/, 1])
               spec = 0
               t[current_template = match] ||= []
             end


### PR DESCRIPTION
* независимость от Chart.Name;
* изменена логика выборочного вывода spec-ов (`--template GLOB_PATTERN`):
  * в качестве параметра указывается шаблон пути до spec-ов:
    * chart-a `-t .helm/templates/*_custom`;
    * subchart-a `-t .helm/charts/custom_chart/templates/*_custom`.
  * в качестве параметра указывается шаблон пути генерируемого `helm template` (# Source Chart.Name/templates/custom_name.yaml);
  * пути могут быть как относительными, так и абсолютными.