### PR TITLE
dapp dimg build command: изменена логика опции `--force-save-cache`

### DIFF
--- a/lib/dapp/dimg/build/stage/base.rb
+++ b/lib/dapp/dimg/build/stage/base.rb
@@ -87,7 +87,7 @@ module Dapp
             image.add_service_change_label dapp: dimg.stage_dapp_label
             image.add_service_change_label 'dapp-version'.to_sym => ::Dapp::VERSION
             image.add_service_change_label 'dapp-cache-version'.to_sym => ::Dapp::BUILD_CACHE_VERSION
-            image.add_service_change_label 'dapp-dev-mode'.to_sym => true if dimg.dev_mode_cache?
+            image.add_service_change_label 'dapp-dev-mode'.to_sym => true if dimg.dev_mode?
 
             if dimg.dapp.ssh_auth_sock
               image.add_volume "#{dimg.dapp.ssh_auth_sock}:/tmp/dapp-ssh-agent"

--- a/lib/dapp/dimg/dimg.rb
+++ b/lib/dapp/dimg/dimg.rb
@@ -42,7 +42,7 @@ module Dapp
       end
 
       def after_stages_build!
-        return unless last_stage.image.built? || dev_mode_cache?
+        return unless last_stage.image.built? || dev_mode? || force_save_cache?
         last_stage.save_in_cache!
         artifacts.each { |artifact| artifact.last_stage.save_in_cache! }
       end
@@ -154,12 +154,12 @@ module Dapp
         dapp.dev_mode?
       end
 
-      def dev_mode_cache?
-        dev_mode? || !!dapp.options[:force_save_cache]
+      def force_save_cache?
+        !!dapp.options[:force_save_cache]
       end
 
       def build_cache_version
-        [::Dapp::BUILD_CACHE_VERSION, dev_mode_cache? ? 1 : 0]
+        [::Dapp::BUILD_CACHE_VERSION, dev_mode? ? 1 : 0]
       end
 
       def introspect_image!(image:, options:)


### PR DESCRIPTION
* при вызове с опцией сохраняется обычный кэш, а не dev, как ранее.