### PR TITLE
Правила пересборки для стадий

### DIFF
--- a/lib/dapp/dimg/build/stage/base.rb
+++ b/lib/dapp/dimg/build/stage/base.rb
@@ -272,7 +272,10 @@ module Dapp
           end
 
           def image_should_be_untagged_condition
-            false
+            return false unless image.tagged?
+            dimg.git_artifacts.any? do |git_artifact|
+              !git_artifact.repo.commit_exists? layer_commit(git_artifact)
+            end
           end
 
           def should_be_not_present?

--- a/lib/dapp/dimg/build/stage/before_install.rb
+++ b/lib/dapp/dimg/build/stage/before_install.rb
@@ -15,6 +15,7 @@ module Dapp
           def context
             [builder_checksum]
           end
+          alias dependencies context
 
           def builder_checksum
             dimg.builder.before_install_checksum
@@ -26,7 +27,9 @@ module Dapp
             end
           end
 
-          alias dependencies context
+          def image_should_be_untagged_condition
+            false
+          end
         end # BeforeInstall
       end # Stage
     end # Build

--- a/lib/dapp/dimg/build/stage/before_install_artifact.rb
+++ b/lib/dapp/dimg/build/stage/before_install_artifact.rb
@@ -7,6 +7,10 @@ module Dapp
             @prev_stage = BeforeInstall.new(dimg, self)
             super
           end
+
+          def image_should_be_untagged_condition
+            false
+          end
         end # BeforeInstallArtifact
       end # Stage
     end # Build

--- a/lib/dapp/dimg/build/stage/from.rb
+++ b/lib/dapp/dimg/build/stage/from.rb
@@ -34,6 +34,10 @@ module Dapp
             []
           end
 
+          def image_should_be_untagged_condition
+            false
+          end
+
           def should_not_be_detailed?
             from_image.tagged?
           end

--- a/lib/dapp/dimg/build/stage/ga_base.rb
+++ b/lib/dapp/dimg/build/stage/ga_base.rb
@@ -24,13 +24,6 @@ module Dapp
             true
           end
 
-          def image_should_be_untagged_condition
-            return false unless image.tagged?
-            dimg.git_artifacts.any? do |git_artifact|
-              !git_artifact.repo.commit_exists? layer_commit(git_artifact)
-            end
-          end
-
           protected
 
           def should_not_be_detailed?


### PR DESCRIPTION
* так как комиты стали использоваться из лейблов образов предыдущих стадий (#443), возможна такая ситуация, что невалидные комиты содержатся в обычных стадиях, а идущие до них `g_a` стадии находятся в состоянии `NOT_PRESENT`, пересборка не выполнится. Таким образом, невалидные комиты надо проверять во всех стадиях, где они хранятся. Исключением являются стадии `from`, `before_install` и `before_install_artifact`.