### PR TITLE
Фикс проблемы с отсутствием файлов после наложения latest патча (0.19 backport)

### DIFF
--- a/lib/dapp/dimg/build/stage/base.rb
+++ b/lib/dapp/dimg/build/stage/base.rb
@@ -188,7 +188,7 @@ module Dapp
 
           def layer_commit(git_artifact)
             commits[git_artifact] ||= begin
-              if image.tagged?
+              if image.built?
                 image.labels["dapp-git-#{git_artifact.paramshash}-commit"]
               else
                 git_artifact.latest_commit


### PR DESCRIPTION
Проверка по image.built? вместо image.tagged? при получении коммита стадии.