### PR TITLE
DAPP_CHEF_DEBUG=yes для debug-вывода в chef, (fix) После обновления с 0.21.2 на 0.21.3 перестала работать конструкция с внешним гитом

### DIFF
--- a/lib/dapp/dimg/builder/chef.rb
+++ b/lib/dapp/dimg/builder/chef.rb
@@ -192,8 +192,9 @@ module Dapp
         @install_chef_solo_stage_config[stage] ||= true.tap do
           stage_build_path(stage).join('config.rb').write [
             "file_cache_path \"/.dapp/chef/cache\"\n",
-            "cookbook_path \"#{container_stage_build_path(stage).join('cookbooks')}\"\n"
-          ].join
+            "cookbook_path \"#{container_stage_build_path(stage).join('cookbooks')}\"\n",
+            ("log_level :debug\n" if ENV["DAPP_CHEF_DEBUG"]),
+          ].compact.join
         end
       end
 

--- a/lib/dapp/dimg/git_repo/remote.rb
+++ b/lib/dapp/dimg/git_repo/remote.rb
@@ -2,6 +2,8 @@ module Dapp
   module Dimg
     module GitRepo
       class Remote < Base
+        CACHE_VERSION = 1
+
         attr_reader :url
 
         def initialize(dimg, name, url:)
@@ -39,7 +41,7 @@ module Dapp
         end
 
         def path
-          Pathname(dimg.build_path('git_repo_remote', name).to_s)
+          Pathname(dimg.build_path("remote_git_repo", CACHE_VERSION.to_s, name).to_s)
         end
 
         def fetch!(branch = nil)


### PR DESCRIPTION
## (fix) После обновления с 0.21.2 на 0.21.3 перестала работать конструкция с внешним гитом
Поменялась структура кеша git-remote-repository в build-dir, но продолжали использоваться старые каталоги, которые создавал dapp.
Для решения были переименованы актуальные каталоги с кешом, оставлена возможность менять версию кеша из исходников dapp.
На данный момент кеш git-remote-repository находится в `<build-dir>/remote_git_repo/<cache-version=1>/<group>/<name>`.
