### PR TITLE
(fix) Проверка сертификатов на deploy сервере в 22версии не работала

### DIFF
--- a/lib/dapp/cli/command/base.rb
+++ b/lib/dapp/cli/command/base.rb
@@ -68,10 +68,16 @@ module Dapp
           dapp = ::Dapp::Dapp.new(options: options)
 
           log_dapp_running_time(dapp, ignore: !log_running_time) do
-            if block_given?
-              yield dapp
-            elsif !run_method.nil?
-              dapp.public_send(run_method)
+            begin
+              before_dapp_run_command(dapp)
+
+              if block_given?
+                yield dapp
+              elsif !run_method.nil?
+                dapp.public_send(run_method)
+              end
+            ensure
+              dapp.terminate
             end
           end
         end
@@ -89,6 +95,11 @@ module Dapp
 
         def run(_argv = ARGV)
           raise
+        end
+
+        def before_dapp_run_command(dapp, &blk)
+          yield if block_given?
+          dapp.try_host_docker_login
         end
 
         def cli_options(**kwargs)

--- a/lib/dapp/dapp.rb
+++ b/lib/dapp/dapp.rb
@@ -126,7 +126,8 @@ module Dapp
       self.class.host_docker_tmp_config_dir
     end
 
-    def host_docker_login
+    def try_host_docker_login
+      return if options[:without_registry]
       return unless option_repo
 
       validate_repo_name!(option_repo)

--- a/lib/dapp/dimg/cli/command/base.rb
+++ b/lib/dapp/dimg/cli/command/base.rb
@@ -6,21 +6,6 @@ module Dapp::Dimg::CLI
         run_dapp_command(run_method, options: cli_options(dimgs_patterns: cli_arguments))
       end
 
-      def run_dapp_command(run_method, options: {}, log_running_time: true)
-        super(nil, options: options, log_running_time: log_running_time) do |dapp|
-          begin
-            dapp.host_docker_login
-            if block_given?
-              yield dapp
-            elsif !run_method.nil?
-              dapp.public_send(run_method)
-            end
-          ensure
-            dapp.terminate
-          end
-        end
-      end
-
       def run_method
         class_to_lowercase
       end

--- a/lib/dapp/kube/cli/command/kube/lint.rb
+++ b/lib/dapp/kube/cli/command/kube/lint.rb
@@ -56,18 +56,22 @@ BANNER
 
       def run(argv = ARGV)
         self.class.parse_options(self, argv)
+        run_dapp_command(run_method, options: cli_options, log_running_time: false)
+      end
 
-        run_dapp_command(nil, options: cli_options, log_running_time: false) do |dapp|
+      def before_dapp_run_command(dapp, &blk)
+        super(dapp) do
+          yield if block_given?
+
+          # Опция repo определяется в данном хуке, чтобы установить
+          # значение по умолчанию из объекта dapp: dapp.name
           repo = if not cli_arguments[0].nil?
             self.class.required_argument(self, 'repo')
           else
             dapp.name
           end
-
           dapp.options[:repo] = repo
-
-          dapp.public_send(run_method)
-        end
+        end # super
       end
 
     end

--- a/lib/dapp/kube/cli/command/kube/render.rb
+++ b/lib/dapp/kube/cli/command/kube/render.rb
@@ -65,19 +65,24 @@ BANNER
 
       def run(argv = ARGV)
         self.class.parse_options(self, argv)
+        run_dapp_command(run_method, options: cli_options, log_running_time: false)
+      end
 
-        run_dapp_command(nil, options: cli_options, log_running_time: false) do |dapp|
+      def before_dapp_run_command(dapp, &blk)
+        super(dapp) do
+          yield if block_given?
+
+          # Опция repo определяется в данном хуке, чтобы установить
+          # значение по умолчанию из объекта dapp: dapp.name
           repo = if not cli_arguments[0].nil?
             self.class.required_argument(self, 'repo')
           else
             dapp.name
           end
-
           dapp.options[:repo] = repo
-
-          dapp.public_send(run_method)
-        end
+        end # super
       end
+
     end
   end
 end


### PR DESCRIPTION
* Автологин в docker
    * Перенесен из ns=dimg на уровень выше в dapp
    * Отрабатывает при наличии параметра repo и параметров registry-*
    * Не отрабатывает в режиме --without-registry (для dapp kube deploy)

* Исправлен баг в использовании excon
    * 2 параллельных потока пользовались excon
    * один из потоков менял глобальные параметры Excon.defaults
    * другой поток использовал эти параметры
    * проявлялось как "невозможно проверить сертифкат" при запуске деплоя