### PR TITLE
(fix) Использование slug для всех docker тегов из любых параметров

### DIFF
--- a/lib/dapp/dapp/option_tags.rb
+++ b/lib/dapp/dapp/option_tags.rb
@@ -14,7 +14,7 @@ module Dapp
           [simple_tags, branch_tags, commit_tags, build_tags, ci_tags].reduce({}) do |some_tags_by_scheme, tags_by_scheme|
             tags_by_scheme.in_depth_merge(some_tags_by_scheme)
           end.tap do |tags_by_scheme|
-            [:git_branch, :git_tag].each do |scheme|
+            [:git_branch, :git_tag, :custom].each do |scheme|
               tags_by_scheme[scheme].map!(&method(:consistent_uniq_slugify)) unless tags_by_scheme[scheme].nil?
             end
             tags_by_scheme[:custom] = [:latest] if tags_by_scheme.values.flatten.empty?

--- a/lib/dapp/kube/dapp/command/common.rb
+++ b/lib/dapp/kube/dapp/command/common.rb
@@ -264,7 +264,7 @@ image: {{ tuple $name $context | include "_dimg2" }}
           end
 
           def kube_release_name
-            consistent_uniq_slugify("#{name}-#{kube_namespace}")
+            "#{name}-#{kube_namespace}"
           end
 
           { encode: :generate, decode: :extract }.each do |type, secret_method|
@@ -346,7 +346,7 @@ image: {{ tuple $name $context | include "_dimg2" }}
           end
 
           def namespace_option
-            options[:namespace].nil? ? nil : options[:namespace].tr('_', '-')
+            options[:namespace].nil? ? nil : consistent_uniq_slugify(options[:namespace])
           end
 
           def kube_namespace

--- a/lib/dapp/kube/dapp/command/lint.rb
+++ b/lib/dapp/kube/dapp/command/lint.rb
@@ -31,7 +31,7 @@ module Dapp
             kube_check_helm_chart!
 
             repo = option_repo
-            docker_tag = options[:docker_tag]
+            docker_tag = consistent_uniq_slugify(options[:docker_tag])
 
             with_kube_tmp_lint_chart_dir do
               kube_copy_chart


### PR DESCRIPTION
* Использование consistent-uniq-slug для:
    * параметра --tag (тег docker образа)
    * параметра --namespace (kubernetes).
* Зачем сделано:
    * Т.к. эти параметры не имею смысла без slug.
    * Для параметров указанных пользователем будет сохранена совместимость с текущими конфигурациями.
        * Т.е. если в gitlab-ci написано --tag <branch-name> и кто-то коммитнул имя бранча, которое надо прогнать через slug, то все сработает без изменения конфигурации.
* Имя helm релиза не использует slug, т.к. состоит из компонентов, которые гарантированно уже slug'нутые (имя dapp и namespace).