### PR TITLE
Выпилено использование бинарника docker для login в registry на deploy-сервере

### DIFF
--- a/lib/dapp.rb
+++ b/lib/dapp.rb
@@ -24,6 +24,7 @@ require 'openssl'
 require 'etc'
 require 'zlib'
 require 'slugify'
+require 'base64'
 
 require 'dapp/version'
 require 'dapp/core_ext/hash'

--- a/lib/dapp/cli/command/base.rb
+++ b/lib/dapp/cli/command/base.rb
@@ -64,12 +64,12 @@ module Dapp
           super()
         end
 
-        def run_dapp_command(run_method, options: {}, log_running_time: true)
+        def run_dapp_command(run_method, options: {}, log_running_time: true, try_host_docker_login: false)
           dapp = ::Dapp::Dapp.new(options: options)
 
           log_dapp_running_time(dapp, ignore: !log_running_time) do
             begin
-              before_dapp_run_command(dapp)
+              dapp.try_host_docker_login if try_host_docker_login
 
               if block_given?
                 yield dapp
@@ -95,11 +95,6 @@ module Dapp
 
         def run(_argv = ARGV)
           raise
-        end
-
-        def before_dapp_run_command(dapp, &blk)
-          yield if block_given?
-          dapp.try_host_docker_login
         end
 
         def cli_options(**kwargs)

--- a/lib/dapp/dimg/cli/command/dimg/push.rb
+++ b/lib/dapp/dimg/cli/command/dimg/push.rb
@@ -59,7 +59,9 @@ BANNER
         def run(argv = ARGV)
           self.class.parse_options(self, argv)
           repo = self.class.required_argument(self, 'repo')
-          run_dapp_command(run_method, options: cli_options(dimgs_patterns: cli_arguments, repo: repo))
+          run_dapp_command(run_method,
+                           options: cli_options(dimgs_patterns: cli_arguments, repo: repo),
+                           try_host_docker_login: true)
         end
       end
     end

--- a/lib/dapp/dimg/cli/command/dimg/stages/pull.rb
+++ b/lib/dapp/dimg/cli/command/dimg/stages/pull.rb
@@ -25,7 +25,9 @@ BANNER
           def run(argv = ARGV)
             self.class.parse_options(self, argv)
             repo = self.class.required_argument(self, 'repo')
-            run_dapp_command(:stages_pull, options: cli_options(dimgs_patterns: cli_arguments, repo: repo))
+            run_dapp_command(:stages_pull,
+                             options: cli_options(dimgs_patterns: cli_arguments, repo: repo),
+                             try_host_docker_login: true)
           end
         end
       end

--- a/lib/dapp/dimg/cli/command/dimg/stages/push.rb
+++ b/lib/dapp/dimg/cli/command/dimg/stages/push.rb
@@ -21,7 +21,9 @@ BANNER
           def run(argv = ARGV)
             self.class.parse_options(self, argv)
             repo = self.class.required_argument(self, 'repo')
-            run_dapp_command(:stages_push, options: cli_options(dimgs_patterns: cli_arguments, repo: repo))
+            run_dapp_command(:stages_push,
+                             options: cli_options(dimgs_patterns: cli_arguments, repo: repo),
+                             try_host_docker_login: true)
           end
         end
       end

--- a/lib/dapp/kube/cli/command/kube/deploy.rb
+++ b/lib/dapp/kube/cli/command/kube/deploy.rb
@@ -83,26 +83,22 @@ BANNER
 
       def run(argv = ARGV)
         self.class.parse_options(self, argv)
-        run_dapp_command(run_method, options: cli_options)
-      end
 
-      def before_dapp_run_command(dapp, &blk)
-        super(dapp) do
-          yield if block_given?
+        options = cli_options
+        options[:tag] = [*options.delete(:tag), *options.delete(:image_version)]
 
-          # Опция repo определяется в данном хуке, чтобы установить
-          # значение по умолчанию из объекта dapp: dapp.name
+        run_dapp_command(nil, options: options) do |dapp|
           repo = if not cli_arguments[0].nil?
             self.class.required_argument(self, 'repo')
           else
             dapp.name
           end
+
           dapp.options[:repo] = repo
 
-          dapp.options[:tag] = [*dapp.options.delete(:tag), *dapp.options.delete(:image_version)]
-        end # super
+          dapp.public_send(run_method)
+        end
       end
-
     end
   end
 end

--- a/lib/dapp/kube/cli/command/kube/lint.rb
+++ b/lib/dapp/kube/cli/command/kube/lint.rb
@@ -56,24 +56,19 @@ BANNER
 
       def run(argv = ARGV)
         self.class.parse_options(self, argv)
-        run_dapp_command(run_method, options: cli_options, log_running_time: false)
-      end
 
-      def before_dapp_run_command(dapp, &blk)
-        super(dapp) do
-          yield if block_given?
-
-          # Опция repo определяется в данном хуке, чтобы установить
-          # значение по умолчанию из объекта dapp: dapp.name
+        run_dapp_command(nil, options: cli_options, log_running_time: false) do |dapp|
           repo = if not cli_arguments[0].nil?
             self.class.required_argument(self, 'repo')
           else
             dapp.name
           end
-          dapp.options[:repo] = repo
-        end # super
-      end
 
+          dapp.options[:repo] = repo
+
+          dapp.public_send(run_method)
+        end
+      end
     end
   end
 end

--- a/lib/dapp/kube/cli/command/kube/render.rb
+++ b/lib/dapp/kube/cli/command/kube/render.rb
@@ -65,24 +65,18 @@ BANNER
 
       def run(argv = ARGV)
         self.class.parse_options(self, argv)
-        run_dapp_command(run_method, options: cli_options, log_running_time: false)
-      end
-
-      def before_dapp_run_command(dapp, &blk)
-        super(dapp) do
-          yield if block_given?
-
-          # Опция repo определяется в данном хуке, чтобы установить
-          # значение по умолчанию из объекта dapp: dapp.name
+        run_dapp_command(nil, options: cli_options, log_running_time: false) do |dapp|
           repo = if not cli_arguments[0].nil?
             self.class.required_argument(self, 'repo')
           else
             dapp.name
           end
-          dapp.options[:repo] = repo
-        end # super
-      end
 
+          dapp.options[:repo] = repo
+
+          dapp.public_send(run_method)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
* до полного перехода на использование api используется в следующих командах:
  * dapp dimg push/spush;
  * dapp dimg stages pull/push.
* для аутентификации docker registry api использует:
  * значения пользовательских опций `--registry-username`, `--registry-password`;
  * переменная окружения CI_JOB_TOKEN;
  * полученный token из конфига docker-а.