### PR TITLE
Мелкие правки

### DIFF
--- a/bin/dapp
+++ b/bin/dapp
@@ -18,6 +18,9 @@ begin
     end
   rescue ::SystemExit
     raise
+  rescue Errno::EPIPE => _e
+    $stderr.puts(Dapp::Dapp.paint_string('Broken pipe!', :warning))
+    exit 1
   rescue ::Exception => e
     "/tmp/dapp-stacktrace-#{SecureRandom.uuid}.out".tap do |filename|
       ::File.open(filename, 'w') do |dapp_stacktrace|

--- a/lib/dapp/helper/yaml.rb
+++ b/lib/dapp/helper/yaml.rb
@@ -1,8 +1,9 @@
 module Dapp
   module Helper
     module YAML
-      def yaml_load_file(file_path, hash: true)
-        yaml_load(File.read(file_path), hash: hash)
+      def yaml_load_file(file_path, hash: true, default: {})
+        return default if (context = File.read(file_path).strip).empty?
+        yaml_load(context, hash: hash)
       rescue ::Dapp::Error::Dapp => e
         raise ::Dapp::Error::Dapp, code: :yaml_file_incorrect, data: { file: file_path, message: e.net_status[:data][:message] }
       end

--- a/lib/dapp/kube/dapp/command/lint.rb
+++ b/lib/dapp/kube/dapp/command/lint.rb
@@ -60,13 +60,9 @@ module Dapp
                 end
               end
 
-              all_values['global'] = {
-                'namespace' => kube_namespace,
-                'dapp' => {
-                  'repo' => repo,
-                  'docker_tag' => docker_tag
-                }
-              }
+              all_values['global'] ||= {}
+              all_values['global']['namespace'] = kube_namespace
+              all_values['global']['dapp'] = { 'repo' => repo, 'docker_tag' => docker_tag }
 
               kube_chart_path_for_helm.join("values.yaml").write YAML.dump(all_values)
 


### PR DESCRIPTION
* Игнорирование пустых yaml файлов в рамках команд развёртки (close https://github.com/flant/dapp/issues/457).
* dapp kube lint command: fix (close https://github.com/flant/dapp/issues/456):
  * cистемные глобальные опции перетирали пользовательские.
* Обработка прерывания соединения при перенаправлении вывода dapp (close https://github.com/flant/dapp/issues/455).