### PR TITLE
Фикс проблемы с копированием файлов типа wh.jpg

### DIFF
--- a/lib/dapp/dimg/build/stage/artifact_default.rb
+++ b/lib/dapp/dimg/build/stage/artifact_default.rb
@@ -32,7 +32,7 @@ module Dapp
           def safe_cp(from, to, owner, group, include_paths = [], exclude_paths = [])
             ''.tap do |cmd|
               cmd << dimg.dapp.rsync_bin
-              cmd << ' --archive --links'
+              cmd << ' --archive --links --inplace'
               cmd << " --chown=#{owner}:#{group}" if owner or group
 
               if include_paths.any?

--- a/lib/dapp/dimg/builder/chef/cookbook.rb
+++ b/lib/dapp/dimg/builder/chef/cookbook.rb
@@ -87,7 +87,7 @@ module Dapp
             "#{builder.dimg.dapp.mkdir_bin} -p ~/.ssh",
             'echo "Host *" >> ~/.ssh/config',
             'echo "    StrictHostKeyChecking no" >> ~/.ssh/config',
-            *local_paths.map {|path| "#{builder.dimg.dapp.rsync_bin} --archive --relative #{path} /tmp/local_cookbooks"},
+            *local_paths.map {|path| "#{builder.dimg.dapp.rsync_bin} --inplace --archive --relative #{path} /tmp/local_cookbooks"},
             "cd /tmp/local_cookbooks/#{path}",
             "cp #{tmp_berksfile_path} Berksfile",
             "cp #{tmp_metadata_path} metadata.rb",


### PR DESCRIPTION
Опция --inplace для rsync, чтобы не создавать временные файлы.
Файлы, начинающиеся на .wh в aufs являются служебными.