### PR TITLE
DAPP_DIMG_CLEANUP_REGISTRY_PASSWORD используется для dapp dimg cleanup repo

### DIFF
--- a/lib/dapp/dapp.rb
+++ b/lib/dapp/dapp.rb
@@ -188,8 +188,8 @@ module Dapp
       def docker_credentials
         if options.key?(:registry_username) && options.key?(:registry_password)
           [options[:registry_username], options[:registry_password]]
-        elsif ENV.key?('DAPP_CI_JOB_TOKEN') || ENV.key?('CI_JOB_TOKEN')
-          ['gitlab-ci-token', ENV['DAPP_CI_JOB_TOKEN'] || ENV['CI_JOB_TOKEN']]
+        elsif ENV.key?('CI_JOB_TOKEN')
+          ['gitlab-ci-token', ENV['CI_JOB_TOKEN']]
         end
       end
 

--- a/lib/dapp/dimg/cli/command/dimg/cleanup_repo.rb
+++ b/lib/dapp/dimg/cli/command/dimg/cleanup_repo.rb
@@ -24,10 +24,12 @@ BANNER
                boolean: true
 
         option :registry_username,
-               long: '--registry-username USERNAME'
+               long: '--registry-username USERNAME',
+               default: ENV.key?("DAPP_DIMG_CLEANUP_REGISTRY_PASSWORD") ? : "dapp-cleanup-repo" : nil # FIXME: https://gitlab.com/gitlab-org/gitlab-ce/issues/41384
 
         option :registry_password,
-               long: '--registry-password PASSWORD'
+               long: '--registry-password PASSWORD',
+               default: ENV["DAPP_DIMG_CLEANUP_REGISTRY_PASSWORD"] # FIXME: https://gitlab.com/gitlab-org/gitlab-ce/issues/41384
 
         def run(argv = ARGV)
           self.class.parse_options(self, argv)


### PR DESCRIPTION
Передумали использовать DAPP_CI_JOB_TOKEN, поэтому он выпилен за ненадобностью.