### PR TITLE
(fix) kube render undefined method `join' for nil

### DIFF
--- a/lib/dapp/kube/helm/release.rb
+++ b/lib/dapp/kube/helm/release.rb
@@ -78,7 +78,7 @@ module Dapp
           end
 
           t.each do |template, specs|
-            t[template] = "---\n#{specs.map(&:join).join("---\n").strip}"
+            t[template] = "---\n#{specs.reject(&:nil?).map(&:join).join("---\n").strip}"
           end
         end
       end


### PR DESCRIPTION
Если в шаблонах есть 2 yaml-разделителя `---` подряд без текста между ними, то dapp kube render падает с ошибкой:

```
lib/dapp/kube/helm/release.rb:81:in `map': undefined method `join' for nil:NilClass (NoMethodError)
```