### PR TITLE
Поддержка git submodules

### DIFF
--- a/config/en/net_status.yml
+++ b/config/en/net_status.yml
@@ -120,7 +120,9 @@ en:
       commit_not_found_in_remote_git_repository: "Remote git repo `%{url}`: commit `%{commit}` not found!\nIf commit has been rebased: run command `dapp dimg stages cleanup local --improper-git-commit`!"
       branch_not_exist_in_remote_git_repository: "Remote git repo `%{url}`: branch `%{branch}` not exist!"
       rugged_protocol_not_supported: "Rugged has been compiled without support for `%{protocol}`.\nGit repositories will not be reachable via `%{protocol}` (`%{url}`).\nRugged.features should include `%{protocol}`."
-      submodule_not_supported: "Git submodules not supported! (`%{path}`)"
+      incorrect_gitmodules_file: "Local git repo with invalid `.gitmodules` file: `%{error}`."
+      git_repository_without_remote_url: "Git repo `%{name}`: remote url cannot be detected!\nYou should check `remote origin url` in `%{path}` repository."
+      git_repository_not_found: "Git repository `%{path}` not found!\nYou should check `remote origin url` in `%{parent_git_path}` repository."
     lock:
       timeout: "Could not obtain lock for `%{name}` within %{timeout} seconds!"
     app:

--- a/lib/dapp/dapp/option_tags.rb
+++ b/lib/dapp/dapp/option_tags.rb
@@ -1,10 +1,6 @@
 module Dapp
   class Dapp
     module OptionTags
-      def git_local_repo
-        @git_repo ||= ::Dapp::Dimg::GitRepo::Own.new(self)
-      end
-
       def tagging_schemes
         %w(git_tag git_branch git_commit custom ci)
       end
@@ -32,13 +28,13 @@ module Dapp
 
       def branch_tags
         return {} unless options[:tag_branch]
-        raise Error::Dapp, code: :git_branch_without_name if (branch = git_local_repo.branch) == 'HEAD'
+        raise Error::Dapp, code: :git_branch_without_name if (branch = git_own_repo.branch) == 'HEAD'
         { git_branch: [branch] }
       end
 
       def commit_tags
         return {} unless options[:tag_commit]
-        { git_commit: [git_local_repo.latest_commit] }
+        { git_commit: [git_own_repo.latest_commit] }
       end
 
       def build_tags

--- a/lib/dapp/dimg/config/directive/git_artifact_remote.rb
+++ b/lib/dapp/dimg/config/directive/git_artifact_remote.rb
@@ -16,7 +16,7 @@ module Dapp
           end
 
           def branch(value)
-            sub_directive_eval { @_branch = value.to_s }
+            sub_directive_eval { @_branch = value }
           end
 
           def commit(value)
@@ -38,7 +38,7 @@ module Dapp
             attr_accessor :_url, :_name, :_branch, :_commit
 
             def _artifact_options
-              super.merge(name: _name, branch: _branch, commit: _commit)
+              super.merge(name: _name, branch: _branch.to_s, commit: _commit.to_s)
             end
 
             def branch(value)

--- a/lib/dapp/dimg/dimg/git_artifact.rb
+++ b/lib/dapp/dimg/dimg/git_artifact.rb
@@ -7,22 +7,34 @@ module Dapp
         end
 
         def local_git_artifacts
-          @local_git_artifact_list ||= begin
+          @local_git_artifact_list ||= [].tap do |artifacts|
             repo = GitRepo::Own.new(self)
             Array(config._git_artifact._local).map do |ga_config|
-              ::Dapp::Dimg::GitArtifact.new(repo, **ga_config._artifact_options)
+              artifacts.concat(generate_git_artifacts(repo, **ga_config._artifact_options))
             end
           end
         end
 
         def remote_git_artifacts
-          @remote_git_artifact_list ||= begin
-            repos = {}
-            Array(config._git_artifact._remote).map do |ga_config|
-              repo_key = [ga_config._url, ga_config._branch]
-              repos[repo_key] ||= GitRepo::Remote.new(self, ga_config._name, url: ga_config._url).tap { |repo| repo.fetch!(ga_config._branch) }
-              ::Dapp::Dimg::GitArtifact.new(repos[repo_key], **ga_config._artifact_options)
+          @remote_git_artifact_list ||= [].tap do |artifacts|
+            Array(config._git_artifact._remote).each do |ga_config|
+              repo = GitRepo::Remote.get_or_init(self, ga_config._name, url: ga_config._url, branch: ga_config._branch)
+              artifacts.concat(generate_git_artifacts(repo, **ga_config._artifact_options))
             end
+          end
+        end
+
+        def generate_git_artifacts(repo, **git_artifact_options)
+          [].tap do |artifacts|
+            artifacts << (artifact = ::Dapp::Dimg::GitArtifact.new(repo, **git_artifact_options))
+            artifacts.concat(generate_git_submodules_artifacts(artifact))
+          end
+        end
+
+        def generate_git_submodules_artifacts(artifact)
+          [].tap do |artifacts|
+            artifacts.concat(submodules_artifacts = artifact.submodules_artifacts)
+            artifacts.concat(submodules_artifacts.map(&method(:generate_git_submodules_artifacts)).flatten)
           end
         end
       end # GitArtifact

--- a/lib/dapp/dimg/git_artifact.rb
+++ b/lib/dapp/dimg/git_artifact.rb
@@ -225,7 +225,7 @@ module Dapp
       def archive_file_with_tar_writer(stage, commit)
         tar_write(repo.dimg.tmp_path('archives', archive_file_name(commit))) do |tar|
           each_archive_entry(stage, commit) do |path, content, mode|
-            if mode == 40960 # symlink
+            if mode == 0o120000 # symlink
               tar.add_symlink path, content, mode
             else
               tar.add_file path, mode do |tf|
@@ -244,7 +244,7 @@ module Dapp
           each_archive_entry(stage, commit) do |path, content, mode|
             file_path = repo.dimg.tmp_path(relative_archive_file_path, path)
 
-            if mode == 40960 # symlink
+            if mode == 0o120000 # symlink
               FileUtils.symlink(content, file_path)
             else
               IO.write(file_path, content)
@@ -397,6 +397,10 @@ module Dapp
           end
           repo.patches(from_commit, to_commit, paths: paths, exclude_paths: exclude_paths(true), **options)
         end
+      end
+
+      def submodule_mode?(mode) # FIXME
+        mode == 0o160000
       end
 
       def include_paths_or_cwd

--- a/lib/dapp/dimg/git_repo/own.rb
+++ b/lib/dapp/dimg/git_repo/own.rb
@@ -45,6 +45,13 @@ module Dapp
         rescue Rugged::OdbError, TypeError => _e
           raise Error::Rugged, code: :commit_not_found_in_local_git_repository, data: { commit: commit }
         end
+
+        def exist?
+          super
+        rescue Error::Rugged => e
+          return false if e.net_status[:code] == :local_git_repository_does_not_exist
+          raise
+        end
       end
     end
   end

--- a/lib/dapp/dimg/git_repo/own.rb
+++ b/lib/dapp/dimg/git_repo/own.rb
@@ -23,6 +23,13 @@ module Dapp
         # NOTICE: Параметры {from: nil, to: nil} можно указать только для Own repo.
         # NOTICE: Для Remote repo такой вызов не имеет смысла и это ошибка пользователя класса Remote.
 
+        def submodules_params(commit, paths: [], exclude_paths: [])
+          return super unless commit.nil?
+          return []    unless File.file?((gitmodules_file_path = File.join(workdir_path, '.gitmodules')))
+
+          submodules_params_base(File.read(gitmodules_file_path), paths: paths, exclude_paths: exclude_paths)
+        end
+
         def diff(from, to, **kwargs)
           if from.nil? and to.nil?
             mid_commit = latest_commit

--- a/lib/dapp/dimg/git_repo/remote.rb
+++ b/lib/dapp/dimg/git_repo/remote.rb
@@ -4,6 +4,11 @@ module Dapp
       class Remote < Base
         CACHE_VERSION = 1
 
+        def self.get_or_init(dimg, name, url:, branch:)
+          key = [url, branch]
+          (@repos ||= {})[key] ||= new(dimg, name, url: url).tap { |repo| repo.fetch!(branch) }
+        end
+
         attr_reader :url
 
         def initialize(dimg, name, url:)

--- a/lib/dapp/dimg/git_repo/remote.rb
+++ b/lib/dapp/dimg/git_repo/remote.rb
@@ -64,7 +64,11 @@ module Dapp
             end
 
             dapp.log_secondary_process(dapp.t(code: 'process.git_artifact_fetch', data: { url: url }), short: true) do
-              git.fetch('origin', [branch], credentials: _rugged_credentials)
+              begin
+                git.fetch('origin', [branch], credentials: _rugged_credentials)
+              rescue Rugged::SshError => e
+                raise Error::Rugged, code: :rugged_remote_error, data: { url: url, message: e.message.strip }
+              end
               raise Error::Rugged, code: :branch_not_exist_in_remote_git_repository, data: { branch: branch, url: url } unless branch_exist?(branch)
             end
           end unless dimg.ignore_git_fetch || dapp.dry_run?

--- a/lib/dapp/helper/trivia.rb
+++ b/lib/dapp/helper/trivia.rb
@@ -28,6 +28,25 @@ module Dapp
         Pathname.new(File.join(base.to_s, *path.compact.map(&:to_s)))
       end
 
+      def check_path?(path, format)
+        path_checker(path) { |checking_path| File.fnmatch(format, checking_path, File::FNM_PATHNAME) }
+      end
+
+      def check_subpath?(path, format)
+        path_checker(format) { |checking_path| File.fnmatch(checking_path, path, File::FNM_PATHNAME) }
+      end
+
+      def path_checker(path)
+        path_parts = path.split('/')
+        checking_path = nil
+
+        until path_parts.empty?
+          checking_path = [checking_path, path_parts.shift].compact.join('/')
+          return true if yield checking_path
+        end
+        false
+      end
+
       def self.class_to_lowercase(class_name = self)
         class_name.to_s.split('::').last.split(/(?=[[:upper:]]|[0-9])/).join('_').downcase.to_s
       end

--- a/lib/dapp/kube/helm/values.rb
+++ b/lib/dapp/kube/helm/values.rb
@@ -36,10 +36,10 @@ module Dapp
           elsif ENV["CI_COMMIT_REF_NAME"]
             ci_info["branch"] = ci_info["ref"] = ENV["CI_COMMIT_REF_NAME"]
             ci_info["is_branch"] = true
-          elsif dapp.git_path and dapp.git_local_repo.branch != "HEAD"
+          elsif dapp.git_own_repo_exist? and dapp.git_local_repo.branch != "HEAD"
             ci_info["branch"] = ci_info["ref"] = dapp.git_local_repo.branch
             ci_info["is_branch"] = true
-          elsif dapp.git_path
+          elsif dapp.git_own_repo_exist?
             git = dapp.git_local_repo.send(:git)
 
             tagref = git.references.find do |r|

--- a/spec/integration/chef_spec.rb
+++ b/spec/integration/chef_spec.rb
@@ -60,7 +60,7 @@ describe Dapp::Dimg::Builder::Chef do
           expect(send(dimod_test_file, reload: true)).not_to eq(old_template_file_values[dimod_test_file])
           expect(send(dimod_test2_file, reload: true)).not_to eq(old_template_file_values[dimod_test2_file])
 
-          expect(send("dapp_#{stage}", reload: true)).to eq(new_file_values[project_file])
+          expect(send("testproject_#{stage}", reload: true)).to eq(new_file_values[project_file])
           expect(send("dimod_test_#{stage}", reload: true)).to eq(new_file_values[dimod_test_file])
           expect(send("dimod_test2_#{stage}", reload: true)).to eq(new_file_values[dimod_test2_file])
         end
@@ -280,8 +280,8 @@ describe Dapp::Dimg::Builder::Chef do
   TEST_FILE_NAMES = %i(foo x_foo x_y_foo bar baz qux
                        burger pizza taco pelmeni
                        kolokolchik koromyslo taburetka batareika
-                       dapp_before_install dapp_install
-                       dapp_before_setup dapp_setup
+                       testproject_before_install testproject_install
+                       testproject_before_setup testproject_setup
                        dimod_test_before_install dimod_test_install
                        dimod_test_before_setup dimod_test_setup
                        dimod_test2_before_install dimod_test2_install

--- a/spec/integration/submodule_spec.rb
+++ b/spec/integration/submodule_spec.rb
@@ -1,0 +1,143 @@
+require_relative '../spec_helper'
+
+describe Dapp::Dimg::Dimg do
+  include SpecHelper::Common
+  include SpecHelper::Dimg
+  include SpecHelper::Git
+  
+  def projects_origins
+    {
+      test: 'https://github.com/flant/dapp-submodule-spec-project-test.git',
+      https: 'https://github.com/flant/dapp-submodule-spec-project-https.git',
+      relative_path: 'https://github.com/flant/dapp-submodule-spec-project-relative-path.git',
+      nested: 'https://github.com/flant/dapp-submodule-spec-project-nested.git',
+      branches: 'https://github.com/flant/dapp-submodule-spec-project-branches.git'
+    }
+  end
+
+  before :all do
+    @project_test_tmpdir = Dir.mktmpdir
+    @project_test_path   = File.join(@project_test_tmpdir, 'dapp-submodule-spec-project-test')
+    git_clone(projects_origins[:test], @project_test_path)
+
+    [:master, :feature].each do |branch|
+      git_checkout(branch, git_dir: @project_test_path)
+      git_submodule_update(git_dir: @project_test_path)
+      (@project_test_md5sum_by_branch ||= {})[branch] = calculate_md5sum(@project_test_path)
+    end
+
+    git_checkout(:master, git_dir: @project_test_path)
+  end
+
+  after :all do
+    FileUtils.rmtree(@project_test_tmpdir)
+  end
+
+  def git_clone(url, path = '.')
+    Rugged::Repository.clone_at(url, path)
+  end
+
+  def git_checkout(branch, git_dir: '.')
+    shellout!("git -C #{git_dir} checkout #{branch}")
+  end
+
+  def git_submodule_update(git_dir: '.')
+    shellout!("git -C #{git_dir} submodule init")
+    shellout!("git -C #{git_dir} submodule update --remote --recursive")
+  end
+
+  def calculate_md5sum(path)
+    shellout!(md5sum_command(path, ignore_git: true))
+      .stdout
+      .strip
+  end
+
+  def md5sum_command(directory, ignore_git: false)
+    shellout_pack_wrapper("find #{directory} -xtype f#{' -not -path "**/.git" -not -path "**/.git/*"' if ignore_git} | xargs md5sum | awk '{ print $1 }' | sort | md5sum | awk '{ print $1 }'")
+  end
+
+  def shellout_pack_wrapper(*cmds)
+    "bash -ec '#{shellout_pack(cmds.join(' && '))}'"
+  end
+
+  def project_test_md5sum(branch = :master)
+    @project_test_md5sum_by_branch[branch]
+  end
+
+  def clone_project_and_expect_submodule(url, expected_md5sum)
+    git_clone(url)
+    expect_submodule(expected_md5sum)
+  end
+
+  def expect_submodule(expected_md5sum)
+    expect { dimg.build! }.to_not raise_error
+    expect(git_submodules_paths.count).to eq 1
+    expect(container_submodule_md5sum(git_submodules_paths.first)).to eq expected_md5sum
+  end
+
+  def git_submodules_paths
+    git_repo
+      .submodules
+      .map(&:path)
+  end
+
+  def container_submodule_md5sum(submodule)
+    cmd = "#{host_docker} run --rm #{dimg.send(:last_stage).image.name} #{md5sum_command(File.join(local_artifact_to, submodule))}"
+    expect { return shellout!(cmd).stdout.strip }.to_not raise_error
+  end
+
+  def local_artifact_to
+    config._git_artifact._local.first._artifact_options[:to]
+  end
+
+  def dapp
+    Dapp::Dapp.new(options: dapp_options)
+  end
+
+  def config
+    dapp.build_configs.first
+  end
+
+  def init_dapp_project
+    git_init
+    dappfile_content = <<EOF
+dimg do
+docker.from 'ubuntu:16.04'
+git.add.to('/app')
+end
+EOF
+    git_change_and_commit('Dappfile', dappfile_content)
+  end
+
+  def git_add_and_commit_submodule(url, name)
+    git_repo.submodules.add(url, name)
+    git_commit
+  end
+
+  it 'local', test_construct: true do
+    init_dapp_project
+    git_add_and_commit_submodule(@project_test_path, 'dapp-submodule-spec-project-test')
+    expect_submodule(project_test_md5sum)
+  end
+
+  it 'https', test_construct: true do
+    clone_project_and_expect_submodule(projects_origins[:https], project_test_md5sum)
+  end
+
+  it 'relative_path', test_construct: true do
+    clone_project_and_expect_submodule(projects_origins[:relative_path], project_test_md5sum)
+  end
+
+  it 'nested', test_construct: true do
+    project_https_path = File.join(@project_test_tmpdir, 'dapp-submodule-spec-project-https')
+    git_clone(projects_origins[:https], project_https_path)
+    git_submodule_update(git_dir: project_https_path)
+    project_https_md5sum = calculate_md5sum(project_https_path)
+
+    clone_project_and_expect_submodule(projects_origins[:nested], project_https_md5sum)
+  end
+
+  it 'branches', test_construct: true do
+    clone_project_and_expect_submodule(projects_origins[:branches], project_test_md5sum(:feature))
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,7 @@ RSpec.configure do |config|
   end
   config.before :each do
     Dapp::Dapp.options.clear
+    Dapp::Dimg::GitRepo::Remote.instance_variable_set(:@repos, nil)
   end
   config.mock_with :rspec do |mocks|
     mocks.allow_message_expectations_on_nil = true

--- a/spec/spec_helper/common.rb
+++ b/spec/spec_helper/common.rb
@@ -46,6 +46,10 @@ module SpecHelper
       expect { yield }.to raise_error { |error| expect(error.net_status[:code]).to be(code) }
     end
 
+    def shellout_pack(cmd)
+      "eval $(echo #{Base64.strict_encode64(cmd)} | base64 --decode)"
+    end
+
     def self.included(base)
       base.extend(self)
     end

--- a/spec/spec_helper/dimg.rb
+++ b/spec/spec_helper/dimg.rb
@@ -11,9 +11,17 @@ module SpecHelper
     end
 
     def dimg_renew
-      @openstruct_config = nil
       @dimg = begin
-        options = { config: openstruct_config, dapp: dapp }
+        options = {}
+        options[:config] = begin
+          if config.is_a?(Dapp::Dimg::Config::Directive::Dimg)
+            config
+          else
+            @openstruct_config = nil
+            openstruct_config
+          end
+        end
+        options[:dapp] = dapp
         Dapp::Dimg::Dimg.new(**options)
       end
     end

--- a/spec/spec_helper/git.rb
+++ b/spec/spec_helper/git.rb
@@ -33,7 +33,7 @@ module SpecHelper
       index = git_repo(git_dir: git_dir).index
       index.add path: relative_path,
                 oid: (Rugged::Blob.from_workdir git_repo(git_dir: git_dir), relative_path),
-                mode: File.symlink?(absolute_path) ? 40960 : File.stat(absolute_path).mode
+                mode: File.symlink?(absolute_path) ? 0o120000 : File.stat(absolute_path).mode
     end
 
     def git_rm(relative_path, git_dir: '.')

--- a/spec/unit/git_artifact_spec.rb
+++ b/spec/unit/git_artifact_spec.rb
@@ -5,505 +5,572 @@ describe Dapp::Dimg::GitArtifact do
   include SpecHelper::Git
   include SpecHelper::Dimg
 
-  before :each do
-    init_git_artifact_local_options
-    git_init
-    stub_stages
-    stub_dimg
-  end
-
-  after :each do
-    docker_cleanup
-  end
-
-  def init_git_artifact_local_options
-    @cwd           = ''
-    @to            = '/dist'
-    @include_paths = []
-    @exclude_paths = []
-    @branch        = 'master'
-    @group         = 'root'
-    @owner         = 'root'
-  end
-
-  def stubbed_stage
-    instance_double(Dapp::Dimg::Build::Stage::Base).tap do |instance|
-      allow(instance).to receive(:prev_stage=)
+  context 'dimg' do
+    before :each do
+      init_git_artifact_local_options
+      git_init
+      stub_stages
+      stub_dimg
     end
-  end
 
-  def stub_stages
-    @stage_commit = {}
-    [Dapp::Dimg::Build::Stage::GAArchive, Dapp::Dimg::Build::Stage::GALatestPatch].each do |stage|
-      allow_any_instance_of(stage).to receive(:layer_commit) do
-        @stage_commit[stage.name] ||= {}
-        @stage_commit[stage.name][@branch] ||= git_latest_commit(branch: @branch)
+    after :each do
+      docker_cleanup
+    end
+
+    def init_git_artifact_local_options
+      @cwd           = ''
+      @to            = '/dist'
+      @include_paths = []
+      @exclude_paths = []
+      @branch        = 'master'
+      @group         = 'root'
+      @owner         = 'root'
+    end
+
+    def stubbed_stage
+      instance_double(Dapp::Dimg::Build::Stage::Base).tap do |instance|
+        allow(instance).to receive(:prev_stage=)
       end
     end
-    allow_any_instance_of(Dapp::Dimg::Build::Stage::GALatestPatch).to receive(:prev_stage) { g_a_archive_stage }
-  end
 
-  def stub_image
-    instance_double(Dapp::Dimg::Image::Stage).tap do |obj|
-      allow(obj).to receive(:labels) do
-        obj.instance_variable_get(:@_mock_labels) ||
-          obj.instance_variable_set(:@_mock_labels, Hash.new('directory'))
-      end
-
-      allow(obj).to receive(:add_service_change_label) do |**options|
-        options.each do |k, v|
-          obj.labels[k.to_s] = v
+    def stub_stages
+      @stage_commit = {}
+      [Dapp::Dimg::Build::Stage::GAArchive, Dapp::Dimg::Build::Stage::GALatestPatch].each do |stage|
+        allow_any_instance_of(stage).to receive(:layer_commit) do
+          @stage_commit[stage.name] ||= {}
+          @stage_commit[stage.name][@branch] ||= git_latest_commit(branch: @branch)
         end
       end
+      allow_any_instance_of(Dapp::Dimg::Build::Stage::GALatestPatch).to receive(:prev_stage) { g_a_archive_stage }
     end
-  end
 
-  def image_build(*cmds)
-    container_run(*cmds, rm: false).tap do
-      shellout("#{host_docker} commit #{containter_name} #{containter_name}:latest")
-      shellout("#{host_docker} rm #{containter_name}")
-      @spec_image_name = "#{containter_name}:latest"
-    end
-  end
-
-  def container_run(*cmds, rm: true)
-    shellout(["#{host_docker} run",
-              ('--rm' if rm).to_s,
-              "--entrypoint #{g_a_stubbed_dimg.dapp.bash_bin}",
-              "--name #{containter_name}",
-              "--volume #{g_a_stubbed_dimg.tmp_path('archives')}:#{g_a_stubbed_dimg.container_tmp_path('archives')}:ro",
-              "--volume #{g_a_stubbed_dimg.tmp_path('patches')}:#{g_a_stubbed_dimg.container_tmp_path('patches')}:ro",
-              "--volumes-from #{g_a_stubbed_dimg.dapp.gitartifact_container}",
-              "--volumes-from #{g_a_stubbed_dimg.dapp.toolchain_container}",
-              "--volumes-from #{g_a_stubbed_dimg.dapp.base_container}",
-              "--label dapp=#{g_a_stubbed_dimg.dapp.name}",
-              '--label dapp-test=true',
-              image_name.to_s,
-              prepare_container_command(*cmds).to_s].join(' '))
-  end
-
-  def prepare_container_command(*cmds)
-    "-ec '#{g_a_stubbed_dimg.dapp.shellout_pack cmds.join(' && ')}'"
-  end
-
-  def docker_cleanup
-    g_a_stubbed_dimg.dapp.send(:dapp_containers_flush_by_label, 'dapp-test')
-    g_a_stubbed_dimg.dapp.send(:dapp_images_flush_by_label, 'dapp-test')
-  end
-
-  def containter_name
-    @spec_containter_name ||= SecureRandom.uuid
-  end
-
-  def image_name
-    @spec_image_name ||= reset_image_name
-  end
-
-  def reset_image_name
-    @spec_image_name = 'ubuntu:16.04'
-  end
-
-  def g_a_stubbed_dimg
-    @g_a_stubbed_dimg ||= Dapp::Dimg::Dimg.new(dapp: dapp, config: openstruct_config).tap do |obj|
-      orig_method = obj.method(:stage_by_name)
-
-      allow(obj).to receive(:stage_by_name) do |name|
-        if name == :g_a_archive
-          g_a_archive_stage
-        else
-          orig_method.call(name)
-        end
-      end
-    end
-  end
-
-  def g_a_archive_stage
-    @g_a_archive_stage ||= begin
-      Dapp::Dimg::Build::Stage::GAArchive.new(g_a_stubbed_dimg, stubbed_stage).tap do |obj|
-        allow(obj).to receive(:image) do
-          obj.instance_variable_get(:@_stub_image) ||
-            obj.instance_variable_set(:@_stub_image, stub_image)
-        end
-      end
-    end
-  end
-
-  def g_a_latest_patch_stage
-    @g_a_latest_patch_stage ||= Dapp::Dimg::Build::Stage::GALatestPatch.new(g_a_stubbed_dimg, stubbed_stage)
-  end
-
-  def git_artifact
-    Dapp::Dimg::GitArtifact.new(stubbed_repo, **git_artifact_local_options)
-  end
-
-  def stubbed_repo
-    @stubbed_repo ||= Dapp::Dimg::GitRepo::Own.new(g_a_stubbed_dimg)
-  end
-
-  def git_artifact_local_options
-    {
-      cwd:           @cwd,
-      include_paths: @include_paths,
-      exclude_paths: @exclude_paths,
-      branch:        @branch,
-      to:            @to,
-      group:         @group,
-      owner:         @owner
-    }
-  end
-
-  def change_file_by_dev_mode(*args, branch: nil, **kwargs)
-    if @dev_mode
-      change_file(*args, **kwargs)
-    else
-      git_change_and_commit(*args, branch: branch, **kwargs)
-    end
-  end
-
-  def git_change_and_commit(*args, branch: nil, git_dir: '.', **kwargs)
-    git_checkout(branch, git_dir: git_dir) unless branch.nil?
-    super(*args, git_dir: git_dir, **kwargs)
-  end
-
-  def apply_archive
-    apply_command(*git_artifact.apply_archive_command(g_a_archive_stage))
-  end
-
-  def apply_patch
-    apply_command(*git_artifact.apply_patch_command(g_a_latest_patch_stage))
-  end
-
-  def apply_command(*cmds)
-    image_build(*cmds).tap do |res|
-      expect { res.error! }.to_not raise_error
-    end
-  end
-
-  def expect_existing_container_file(path)
-    expect { check_container_file(path).error! }.to_not raise_error
-  end
-
-  def expect_not_existing_container_file(path)
-    expect { check_container_file(path).error! }.to raise_error ::Mixlib::ShellOut::ShellCommandFailed
-  end
-
-  def check_container_file(path)
-    container_run("#{g_a_stubbed_dimg.dapp.test_bin} -f \"#{path}\"")
-  end
-
-  def container_file_path(path)
-    File.join(@to, path)
-  end
-
-  def container_file_stat(path)
-    res = container_run("#{g_a_stubbed_dimg.dapp.stat_bin} -c '%a %u %g' \"#{path}\"")
-    expect { res.error! }.to_not raise_error
-    mode, uid, gid = res.stdout.strip.split
-    { mode: mode, uid: uid, gid: gid }
-  end
-
-  [true, false].each do |dev_mode_context|
-    context("#{dev_mode_context ? 'dev' : 'base'} mode") do
-      before :all do
-        @dev_mode = dev_mode_context
-      end
-
-      def dapp_options
-        default_dapp_options.merge(dev: @dev_mode)
-      end
-
-      context 'base' do
-        def check_archive_by_dev_mode(**kwargs)
-          git_create_branch(kwargs[:branch]) unless kwargs[:branch].nil?
-          check_base(:archive, **kwargs)
+    def stub_image
+      instance_double(Dapp::Dimg::Image::Stage).tap do |obj|
+        allow(obj).to receive(:labels) do
+          obj.instance_variable_get(:@_mock_labels) ||
+            obj.instance_variable_set(:@_mock_labels, Hash.new('directory'))
         end
 
-        def check_patch_by_dev_mode(ignore_init_build: false, add_files: [], added_files: add_files, not_added_files: [], **kwargs)
-          check_archive_by_dev_mode(**kwargs) unless ignore_init_build
-          check_base(:patch, add_files: add_files, added_files: added_files, not_added_files: not_added_files, **kwargs)
-        end
-
-        def check_base(type, add_files: [], added_files: add_files, not_added_files: [], **kwargs)
-          [:cwd, :include_paths, :exclude_paths, :to, :group, :owner, :branch].each do |opt|
-            instance_variable_set(:"@#{opt}", kwargs[opt]) unless kwargs[opt].nil?
-          end
-
-          add_files.each { |file_path| change_file_by_dev_mode(file_path, branch: @branch) }
-
-          send("apply_#{type}")
-
-          added_files.each { |file_path| expect_existing_container_file(container_file_path(file_path)) }
-          not_added_files.each { |file_path| expect_not_existing_container_file(container_file_path(file_path)) }
-        end
-
-        def reset_image
-          reset_image_name
-        end
-
-        [:patch, :archive].each do |type|
-          break if dev_mode_context && type == :archive
-
-          it type.to_s, test_construct: true do
-            send("check_#{type}_by_dev_mode")
-          end
-
-          it "#{type} branch", test_construct: true do
-            send("check_#{type}_by_dev_mode", branch: 'master')
-            reset_image
-            send("check_#{type}_by_dev_mode", add_files: ['not_master.txt'], branch: 'not_master')
-            reset_image
-            send("check_#{type}_by_dev_mode", not_added_files: ['not_master.txt'], branch: 'master')
-          end unless dev_mode_context
-
-          it "#{type} cwd", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(master.txt a/master2.txt),
-                 added_files: ['master2.txt'], not_added_files: %w(a master.txt),
-                 cwd: 'a')
-          end
-
-          it "#{type} paths", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(x/data.txt x/y/data.txt z/data.txt),
-                 added_files: %w(x/y/data.txt z/data.txt), not_added_files: ['x/data.txt'],
-                 include_paths: %w(x/y z))
-          end
-
-          it "#{type} paths (files)", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(x/data.txt x/y/data.txt z/data.txt),
-                 added_files: %w(x/y/data.txt z/data.txt), not_added_files: %w(x/data.txt),
-                 include_paths: %w(x/y/data.txt z/data.txt))
-          end
-
-          it "#{type} paths (globs)", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(x/data.txt x/y/data.txt z/data.txt),
-                 added_files: %w(x/y/data.txt z/data.txt), not_added_files: %w(x/data.txt),
-                 include_paths: %w(x/y/* z/[asdf]ata.txt))
-          end
-
-          it "#{type} paths (glob *.rb)", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(data.rb data.txt x/data.rb),
-                 added_files: %w(data.rb), not_added_files: %w(data.txt x/data.rb),
-                 include_paths: %w(*.rb))
-          end
-
-          it "#{type} paths (glob **/*.rb)", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(data.rb x/data.rb z/data.txt),
-                 added_files: %w(x/data.rb data.rb), not_added_files: %w(z/data.txt),
-                 include_paths: %w(**/*.rb))
-          end
-
-          it "#{type} paths (glob **/dir/**/*)", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(dir/data.rb dir/data/data.rb a/dir.txt b/dir/data.rb b/dir/data.txt),
-                 added_files: %w(dir/data.rb dir/data/data.rb b/dir/data.rb), not_added_files: %w(a/dir.txt b/dir/data.txt),
-                 include_paths: %w(**/dir/**/*.rb))
-          end
-
-          it "#{type} (file doesn't exist)", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(a/data.txt a/x/data.txt a/x/y/data.txt a/z/data.txt),
-                 added_files: [], not_added_files: %w(a/data.txt a/x/data.txt a/x/y/data.txt a/z/data.txt),
-                 cwd: 'a/x/c')
-          end
-
-          it "#{type} cwd and paths", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(a/data.txt a/x/data.txt a/x/y/data.txt a/z/data.txt),
-                 added_files: %w(x/y/data.txt z/data.txt), not_added_files: %w(a data.txt),
-                 cwd: 'a', include_paths: %w(x/y z))
-          end
-
-          it "#{type} exclude_paths", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(x/data.txt x/y/data.txt z/data.txt),
-                 added_files: %w(z/data.txt), not_added_files: %w(x/data.txt x/y/data.txt),
-                 exclude_paths: %w(x))
-          end
-
-          it "#{type} exclude_paths (files)", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(x/data.txt x/y/data.txt z/data.txt),
-                 added_files: %w(x/data.txt), not_added_files: %w(x/y/data.txt z/data.txt),
-                 exclude_paths: %w(x/y/data.txt z/data.txt))
-          end
-
-          it "#{type} exclude_paths (globs)", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(x/data.txt x/y/data.txt z/data.txt),
-                 added_files: %w(x/data.txt), not_added_files: %w(x/y/data.txt z/data.txt),
-                 exclude_paths: %w(x/y/* z/[asdf]*ta.txt))
-          end
-
-          it "#{type} exclude_paths (glob *.rb)", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(data.rb data.txt x/data.rb),
-                 added_files: %w(data.txt x/data.rb), not_added_files: %w(data.rb),
-                 exclude_paths: %w(*.rb))
-          end
-
-          it "#{type} exclude_paths (glob **/*.rb)", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(data.rb x/data.rb z/data.txt),
-                 added_files: %w(z/data.txt), not_added_files: %w(data.rb x/data.rb),
-                 exclude_paths: %w(**/*.rb))
-          end
-
-          it "#{type} exclude_paths (glob **/dir/**/*)", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(dir/data.rb dir/data/data.rb a/dir.txt b/dir/data.rb b/dir/data.txt),
-                 added_files: %w(a/dir.txt b/dir/data.txt), not_added_files: %w(dir/data.rb dir/data/data.rb b/dir/data.rb),
-                 exclude_paths: %w(**/dir/**/*.rb))
-          end
-
-          it "#{type} cwd and exclude_paths", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(a/data.txt a/x/data.txt a/x/y/data.txt a/z/data.txt),
-                 added_files: %w(data.txt z/data.txt), not_added_files: %w(a x/y/data.txt),
-                 cwd: 'a', exclude_paths: %w(x))
-          end
-
-          it "#{type} cwd, paths and exclude_paths", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: %w(a/data.txt a/x/data.txt a/x/y/data.txt a/z/data.txt),
-                 added_files: %w(x/data.txt z/data.txt), not_added_files: %w(a data.txt x/y/data.txt),
-                 cwd: 'a', include_paths: [%w(x z)], exclude_paths: %w(x/y))
-          end
-
-          it "#{type} file with spaces in name", test_construct: true do
-            send("check_#{type}_by_dev_mode", add_files: ['name with spaces'], added_files: ['name with spaces'])
-          end
-        end
-
-        context 'owner and group' do
-          def expect_container_file_credentials(path, uid, gid)
-            file_stat = container_file_stat(path)
-            expect(file_stat[:uid]).to eq uid
-            expect(file_stat[:gid]).to eq gid
-          end
-
-          file_name = 'test_file.txt'
-          uid = '1111'
-          gid = '1111'
-
-          it 'archive owner_and_group', test_construct: true do
-            check_archive_by_dev_mode(add_files: [file_name], owner: uid, group: gid)
-            expect_container_file_credentials(container_file_path(file_name), uid, gid)
-          end unless dev_mode_context
-
-          it 'patch owner_and_group', test_construct: true do
-            check_archive_by_dev_mode(owner: uid, group: gid)
-            check_patch_by_dev_mode(add_files: [file_name], owner: uid, group: gid, ignore_init_build: true)
-            expect_container_file_credentials(container_file_path(file_name), uid, gid)
+        allow(obj).to receive(:add_service_change_label) do |**options|
+          options.each do |k, v|
+            obj.labels[k.to_s] = v
           end
         end
       end
     end
 
-    context 'cycle with cwd' do
-      def expect_container_file_mode(path, mode)
-        expect(mode).to eq container_file_stat(path)[:mode]
+    def image_build(*cmds)
+      container_run(*cmds, rm: false).tap do
+        shellout("#{host_docker} commit #{containter_name} #{containter_name}:latest")
+        shellout("#{host_docker} rm #{containter_name}")
+        @spec_image_name = "#{containter_name}:latest"
       end
+    end
 
-      def change_file_mode(path)
-        file_mode = File.stat(path).mode
-        available_permissions = { 0o100644 => '644', 0o100755 => '755' }
-        permission = available_permissions.keys[available_permissions.keys.index(file_mode) - 1]
-        File.chmod(permission, path)
-        available_permissions[permission]
-      end
+    def container_run(*cmds, rm: true)
+      shellout(["#{host_docker} run",
+                ('--rm' if rm).to_s,
+                "--entrypoint #{g_a_stubbed_dimg.dapp.bash_bin}",
+                "--name #{containter_name}",
+                "--volume #{g_a_stubbed_dimg.tmp_path('archives')}:#{g_a_stubbed_dimg.container_tmp_path('archives')}:ro",
+                "--volume #{g_a_stubbed_dimg.tmp_path('patches')}:#{g_a_stubbed_dimg.container_tmp_path('patches')}:ro",
+                "--volumes-from #{g_a_stubbed_dimg.dapp.gitartifact_container}",
+                "--volumes-from #{g_a_stubbed_dimg.dapp.toolchain_container}",
+                "--volumes-from #{g_a_stubbed_dimg.dapp.base_container}",
+                "--label dapp=#{g_a_stubbed_dimg.dapp.name}",
+                '--label dapp-test=true',
+                image_name.to_s,
+                prepare_container_command(*cmds).to_s].join(' '))
+    end
 
-      [false, true].each do |binary|
-        def add_file_by_dev_mode(*args)
-          git_add_and_commit(*args) unless @dev_mode
-        end
+    def prepare_container_command(*cmds)
+      "-ec '#{g_a_stubbed_dimg.dapp.shellout_pack cmds.join(' && ')}'"
+    end
 
-        def rm_file_by_dev_mode(path)
-          if @dev_mode
-            File.rm(path)
+    def docker_cleanup
+      g_a_stubbed_dimg.dapp.send(:dapp_containers_flush_by_label, 'dapp-test')
+      g_a_stubbed_dimg.dapp.send(:dapp_images_flush_by_label, 'dapp-test')
+    end
+
+    def containter_name
+      @spec_containter_name ||= SecureRandom.uuid
+    end
+
+    def image_name
+      @spec_image_name ||= reset_image_name
+    end
+
+    def reset_image_name
+      @spec_image_name = 'ubuntu:16.04'
+    end
+
+    def g_a_stubbed_dimg
+      @g_a_stubbed_dimg ||= Dapp::Dimg::Dimg.new(dapp: dapp, config: openstruct_config).tap do |obj|
+        orig_method = obj.method(:stage_by_name)
+
+        allow(obj).to receive(:stage_by_name) do |name|
+          if name == :g_a_archive
+            g_a_archive_stage
           else
-            git_rm_and_commit(path)
+            orig_method.call(name)
+          end
+        end
+      end
+    end
+
+    def g_a_archive_stage
+      @g_a_archive_stage ||= begin
+        Dapp::Dimg::Build::Stage::GAArchive.new(g_a_stubbed_dimg, stubbed_stage).tap do |obj|
+          allow(obj).to receive(:image) do
+            obj.instance_variable_get(:@_stub_image) ||
+              obj.instance_variable_set(:@_stub_image, stub_image)
+          end
+        end
+      end
+    end
+
+    def g_a_latest_patch_stage
+      @g_a_latest_patch_stage ||= Dapp::Dimg::Build::Stage::GALatestPatch.new(g_a_stubbed_dimg, stubbed_stage)
+    end
+
+    def git_artifact
+      Dapp::Dimg::GitArtifact.new(stubbed_repo, **git_artifact_local_options)
+    end
+
+    def stubbed_repo
+      @stubbed_repo ||= Dapp::Dimg::GitRepo::Own.new(g_a_stubbed_dimg)
+    end
+
+    def git_artifact_local_options
+      {
+        cwd:           @cwd,
+        include_paths: @include_paths,
+        exclude_paths: @exclude_paths,
+        branch:        @branch,
+        to:            @to,
+        group:         @group,
+        owner:         @owner
+      }
+    end
+
+    def change_file_by_dev_mode(*args, branch: nil, **kwargs)
+      if @dev_mode
+        change_file(*args, **kwargs)
+      else
+        git_change_and_commit(*args, branch: branch, **kwargs)
+      end
+    end
+
+    def git_change_and_commit(*args, branch: nil, git_dir: '.', **kwargs)
+      git_checkout(branch, git_dir: git_dir) unless branch.nil?
+      super(*args, git_dir: git_dir, **kwargs)
+    end
+
+    def apply_archive
+      apply_command(*git_artifact.apply_archive_command(g_a_archive_stage))
+    end
+
+    def apply_patch
+      apply_command(*git_artifact.apply_patch_command(g_a_latest_patch_stage))
+    end
+
+    def apply_command(*cmds)
+      image_build(*cmds).tap do |res|
+        expect { res.error! }.to_not raise_error
+      end
+    end
+
+    def expect_existing_container_file(path)
+      expect { check_container_file(path).error! }.to_not raise_error
+    end
+
+    def expect_not_existing_container_file(path)
+      expect { check_container_file(path).error! }.to raise_error ::Mixlib::ShellOut::ShellCommandFailed
+    end
+
+    def check_container_file(path)
+      container_run("#{g_a_stubbed_dimg.dapp.test_bin} -f \"#{path}\"")
+    end
+
+    def container_file_path(path)
+      File.join(@to, path)
+    end
+
+    def container_file_stat(path)
+      res = container_run("#{g_a_stubbed_dimg.dapp.stat_bin} -c '%a %u %g' \"#{path}\"")
+      expect { res.error! }.to_not raise_error
+      mode, uid, gid = res.stdout.strip.split
+      { mode: mode, uid: uid, gid: gid }
+    end
+
+    [true, false].each do |dev_mode_context|
+      context("#{dev_mode_context ? 'dev' : 'base'} mode") do
+        before :all do
+          @dev_mode = dev_mode_context
+        end
+
+        def dapp_options
+          default_dapp_options.merge(dev: @dev_mode)
+        end
+
+        context 'base' do
+          def check_archive_by_dev_mode(**kwargs)
+            git_create_branch(kwargs[:branch]) unless kwargs[:branch].nil?
+            check_base(:archive, **kwargs)
+          end
+
+          def check_patch_by_dev_mode(ignore_init_build: false, add_files: [], added_files: add_files, not_added_files: [], **kwargs)
+            check_archive_by_dev_mode(**kwargs) unless ignore_init_build
+            check_base(:patch, add_files: add_files, added_files: added_files, not_added_files: not_added_files, **kwargs)
+          end
+
+          def check_base(type, add_files: [], added_files: add_files, not_added_files: [], **kwargs)
+            [:cwd, :include_paths, :exclude_paths, :to, :group, :owner, :branch].each do |opt|
+              instance_variable_set(:"@#{opt}", kwargs[opt]) unless kwargs[opt].nil?
+            end
+
+            add_files.each { |file_path| change_file_by_dev_mode(file_path, branch: @branch) }
+
+            send("apply_#{type}")
+
+            added_files.each { |file_path| expect_existing_container_file(container_file_path(file_path)) }
+            not_added_files.each { |file_path| expect_not_existing_container_file(container_file_path(file_path)) }
+          end
+
+          def reset_image
+            reset_image_name
+          end
+
+          [:patch, :archive].each do |type|
+            break if dev_mode_context && type == :archive
+
+            it type.to_s, test_construct: true do
+              send("check_#{type}_by_dev_mode")
+            end
+
+            it "#{type} branch", test_construct: true do
+              send("check_#{type}_by_dev_mode", branch: 'master')
+              reset_image
+              send("check_#{type}_by_dev_mode", add_files: ['not_master.txt'], branch: 'not_master')
+              reset_image
+              send("check_#{type}_by_dev_mode", not_added_files: ['not_master.txt'], branch: 'master')
+            end unless dev_mode_context
+
+            it "#{type} cwd", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(master.txt a/master2.txt),
+                   added_files: ['master2.txt'], not_added_files: %w(a master.txt),
+                   cwd: 'a')
+            end
+
+            it "#{type} paths", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(x/data.txt x/y/data.txt z/data.txt),
+                   added_files: %w(x/y/data.txt z/data.txt), not_added_files: ['x/data.txt'],
+                   include_paths: %w(x/y z))
+            end
+
+            it "#{type} paths (files)", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(x/data.txt x/y/data.txt z/data.txt),
+                   added_files: %w(x/y/data.txt z/data.txt), not_added_files: %w(x/data.txt),
+                   include_paths: %w(x/y/data.txt z/data.txt))
+            end
+
+            it "#{type} paths (globs)", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(x/data.txt x/y/data.txt z/data.txt),
+                   added_files: %w(x/y/data.txt z/data.txt), not_added_files: %w(x/data.txt),
+                   include_paths: %w(x/y/* z/[asdf]ata.txt))
+            end
+
+            it "#{type} paths (glob *.rb)", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(data.rb data.txt x/data.rb),
+                   added_files: %w(data.rb), not_added_files: %w(data.txt x/data.rb),
+                   include_paths: %w(*.rb))
+            end
+
+            it "#{type} paths (glob **/*.rb)", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(data.rb x/data.rb z/data.txt),
+                   added_files: %w(x/data.rb data.rb), not_added_files: %w(z/data.txt),
+                   include_paths: %w(**/*.rb))
+            end
+
+            it "#{type} paths (glob **/dir/**/*)", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(dir/data.rb dir/data/data.rb a/dir.txt b/dir/data.rb b/dir/data.txt),
+                   added_files: %w(dir/data.rb dir/data/data.rb b/dir/data.rb), not_added_files: %w(a/dir.txt b/dir/data.txt),
+                   include_paths: %w(**/dir/**/*.rb))
+            end
+
+            it "#{type} (file doesn't exist)", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(a/data.txt a/x/data.txt a/x/y/data.txt a/z/data.txt),
+                   added_files: [], not_added_files: %w(a/data.txt a/x/data.txt a/x/y/data.txt a/z/data.txt),
+                   cwd: 'a/x/c')
+            end
+
+            it "#{type} cwd and paths", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(a/data.txt a/x/data.txt a/x/y/data.txt a/z/data.txt),
+                   added_files: %w(x/y/data.txt z/data.txt), not_added_files: %w(a data.txt),
+                   cwd: 'a', include_paths: %w(x/y z))
+            end
+
+            it "#{type} exclude_paths", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(x/data.txt x/y/data.txt z/data.txt),
+                   added_files: %w(z/data.txt), not_added_files: %w(x/data.txt x/y/data.txt),
+                   exclude_paths: %w(x))
+            end
+
+            it "#{type} exclude_paths (files)", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(x/data.txt x/y/data.txt z/data.txt),
+                   added_files: %w(x/data.txt), not_added_files: %w(x/y/data.txt z/data.txt),
+                   exclude_paths: %w(x/y/data.txt z/data.txt))
+            end
+
+            it "#{type} exclude_paths (globs)", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(x/data.txt x/y/data.txt z/data.txt),
+                   added_files: %w(x/data.txt), not_added_files: %w(x/y/data.txt z/data.txt),
+                   exclude_paths: %w(x/y/* z/[asdf]*ta.txt))
+            end
+
+            it "#{type} exclude_paths (glob *.rb)", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(data.rb data.txt x/data.rb),
+                   added_files: %w(data.txt x/data.rb), not_added_files: %w(data.rb),
+                   exclude_paths: %w(*.rb))
+            end
+
+            it "#{type} exclude_paths (glob **/*.rb)", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(data.rb x/data.rb z/data.txt),
+                   added_files: %w(z/data.txt), not_added_files: %w(data.rb x/data.rb),
+                   exclude_paths: %w(**/*.rb))
+            end
+
+            it "#{type} exclude_paths (glob **/dir/**/*)", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(dir/data.rb dir/data/data.rb a/dir.txt b/dir/data.rb b/dir/data.txt),
+                   added_files: %w(a/dir.txt b/dir/data.txt), not_added_files: %w(dir/data.rb dir/data/data.rb b/dir/data.rb),
+                   exclude_paths: %w(**/dir/**/*.rb))
+            end
+
+            it "#{type} cwd and exclude_paths", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(a/data.txt a/x/data.txt a/x/y/data.txt a/z/data.txt),
+                   added_files: %w(data.txt z/data.txt), not_added_files: %w(a x/y/data.txt),
+                   cwd: 'a', exclude_paths: %w(x))
+            end
+
+            it "#{type} cwd, paths and exclude_paths", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: %w(a/data.txt a/x/data.txt a/x/y/data.txt a/z/data.txt),
+                   added_files: %w(x/data.txt z/data.txt), not_added_files: %w(a data.txt x/y/data.txt),
+                   cwd: 'a', include_paths: [%w(x z)], exclude_paths: %w(x/y))
+            end
+
+            it "#{type} file with spaces in name", test_construct: true do
+              send("check_#{type}_by_dev_mode", add_files: ['name with spaces'], added_files: ['name with spaces'])
+            end
+          end
+
+          context 'owner and group' do
+            def expect_container_file_credentials(path, uid, gid)
+              file_stat = container_file_stat(path)
+              expect(file_stat[:uid]).to eq uid
+              expect(file_stat[:gid]).to eq gid
+            end
+
+            file_name = 'test_file.txt'
+            uid = '1111'
+            gid = '1111'
+
+            it 'archive owner_and_group', test_construct: true do
+              check_archive_by_dev_mode(add_files: [file_name], owner: uid, group: gid)
+              expect_container_file_credentials(container_file_path(file_name), uid, gid)
+            end unless dev_mode_context
+
+            it 'patch owner_and_group', test_construct: true do
+              check_archive_by_dev_mode(owner: uid, group: gid)
+              check_patch_by_dev_mode(add_files: [file_name], owner: uid, group: gid, ignore_init_build: true)
+              expect_container_file_credentials(container_file_path(file_name), uid, gid)
+            end
+          end
+        end
+      end
+
+      context 'cycle with cwd' do
+        def expect_container_file_mode(path, mode)
+          expect(mode).to eq container_file_stat(path)[:mode]
+        end
+
+        def change_file_mode(path)
+          file_mode = File.stat(path).mode
+          available_permissions = { 0o100644 => '644', 0o100755 => '755' }
+          permission = available_permissions.keys[available_permissions.keys.index(file_mode) - 1]
+          File.chmod(permission, path)
+          available_permissions[permission]
+        end
+
+        [false, true].each do |binary|
+          def add_file_by_dev_mode(*args)
+            git_add_and_commit(*args) unless @dev_mode
+          end
+
+          def rm_file_by_dev_mode(path)
+            if @dev_mode
+              File.rm(path)
+            else
+              git_rm_and_commit(path)
+            end
+          end
+
+          context binary ? 'binary file' : 'file' do
+            file_path = 'a/data'
+            file_path_without_cwd = 'data'
+
+            before :each do
+              change_file_by_dev_mode(file_path, binary: binary)
+              @cwd = 'a'
+              apply_archive
+            end
+
+            it 'added', test_construct: true do
+              change_file_by_dev_mode('a/data2', binary: binary)
+              apply_patch
+            end
+
+            it 'modified', test_construct: true do
+              change_file_by_dev_mode(file_path, binary: binary)
+              apply_patch
+            end
+
+            it 'change_mode', test_construct: true do
+              expected_permission = change_file_mode(file_path)
+              add_file_by_dev_mode(file_path)
+              apply_patch
+              expect_container_file_mode(container_file_path(file_path_without_cwd), expected_permission)
+            end
+
+            it 'modified and change mode', test_construct: true do
+              expected_permission = change_file_mode(file_path)
+              change_file_by_dev_mode(file_path, binary: binary)
+              apply_patch
+              expect_container_file_mode(container_file_path(file_path_without_cwd), expected_permission)
+            end
+
+            it 'delete', test_construct: true do
+              FileUtils.rm_rf file_path
+              rm_file_by_dev_mode(file_path)
+              apply_patch
+              expect_not_existing_container_file(container_file_path(file_path_without_cwd))
+            end
           end
         end
 
-        context binary ? 'binary file' : 'file' do
-          file_path = 'a/data'
-          file_path_without_cwd = 'data'
+        context 'symlink' do
+          def add_symlink_by_dev_mode(file, link)
+            FileUtils.safe_unlink(link) if File.symlink?(link)
+            change_file_by_dev_mode(file)
+            FileUtils.symlink(file, link)
+            add_file_by_dev_mode(link)
+          end
+
+          def rm_symlink_by_dev_mode(*args)
+            FileUtils.safe_unlink(*args)
+            rm_file_by_dev_mode(*args)
+          end
+
+          def check_container_symlink(path)
+            container_run("#{g_a_stubbed_dimg.dapp.test_bin} -h #{path}")
+          end
+
+          def expext_container_file_link(path, link)
+            expect { check_container_symlink(path).error! }.to_not raise_error
+            expect(container_run("#{g_a_stubbed_dimg.dapp.readlink_bin} -f #{path}").stdout.strip).to eq link
+          end
+
+          symlink_file = 'symlink'
+          symlink2_file = 'symlink2'
 
           before :each do
-            change_file_by_dev_mode(file_path, binary: binary)
-            @cwd = 'a'
+            add_symlink_by_dev_mode('test', symlink_file)
             apply_archive
+            expext_container_file_link(container_file_path(symlink_file), container_file_path('test'))
           end
 
           it 'added', test_construct: true do
-            change_file_by_dev_mode('a/data2', binary: binary)
+            add_symlink_by_dev_mode('test2', symlink2_file)
             apply_patch
+            expext_container_file_link(container_file_path(symlink2_file), container_file_path('test2'))
           end
 
           it 'modified', test_construct: true do
-            change_file_by_dev_mode(file_path, binary: binary)
+            add_symlink_by_dev_mode('test2', symlink_file)
             apply_patch
-          end
-
-          it 'change_mode', test_construct: true do
-            expected_permission = change_file_mode(file_path)
-            add_file_by_dev_mode(file_path)
-            apply_patch
-            expect_container_file_mode(container_file_path(file_path_without_cwd), expected_permission)
-          end
-
-          it 'modified and change mode', test_construct: true do
-            expected_permission = change_file_mode(file_path)
-            change_file_by_dev_mode(file_path, binary: binary)
-            apply_patch
-            expect_container_file_mode(container_file_path(file_path_without_cwd), expected_permission)
+            expext_container_file_link(container_file_path(symlink_file), container_file_path('test2'))
           end
 
           it 'delete', test_construct: true do
-            FileUtils.rm_rf file_path
-            rm_file_by_dev_mode(file_path)
+            rm_symlink_by_dev_mode(symlink_file)
             apply_patch
-            expect_not_existing_container_file(container_file_path(file_path_without_cwd))
+            expect { check_container_symlink(container_file_path(symlink_file)).error! }.to raise_error ::Mixlib::ShellOut::ShellCommandFailed
           end
         end
       end
+    end
+  end
 
-      context 'symlink' do
-        def add_symlink_by_dev_mode(file, link)
-          FileUtils.safe_unlink(link) if File.symlink?(link)
-          change_file_by_dev_mode(file)
-          FileUtils.symlink(file, link)
-          add_file_by_dev_mode(link)
+  context 'submodule' do
+    context 'submodule_url' do
+      def git_artifact_submodule_url(submodule_url, remote_origin_url = nil, remote_origin_url_protocol = nil)
+        double_repo = double('repo')
+        allow(double_repo).to receive(:remote_origin_url) { remote_origin_url }
+        allow(double_repo).to receive(:remote_origin_url_protocol) { remote_origin_url_protocol }
+        git_artifact = Dapp::Dimg::GitArtifact.new(double_repo, to: '/app', branch: 'master')
+        git_artifact.submodule_url(submodule_url)
+      end
+
+      ['git@github.com:group/submodule.git', 'https://github.com/group/submodule.git', '/local/submodule/path'].each do |submodule_url|
+        it submodule_url do
+          expect(git_artifact_submodule_url(submodule_url)).to eq submodule_url
+        end
+      end
+
+      context 'relative_url' do
+        [
+          ['git@github.com:group/project.git', :ssh, 'git@github.com:group/submodule.git'],
+          ['https://github.com/group/project.git', :https, 'https://github.com/group/submodule.git'],
+        ].each do |remote_origin_url, remote_origin_url_protocol, expectation|
+          it remote_origin_url_protocol do
+            expect(git_artifact_submodule_url('../submodule.git', remote_origin_url, remote_origin_url_protocol)).to eq expectation
+          end
         end
 
-        def rm_symlink_by_dev_mode(*args)
-          FileUtils.safe_unlink(*args)
-          rm_file_by_dev_mode(*args)
+        it 'local' do
+          expect { git_artifact_submodule_url('../submodule.git','/local/path', :noname) }.to raise_error RuntimeError
         end
+      end
+    end
 
-        def check_container_symlink(path)
-          container_run("#{g_a_stubbed_dimg.dapp.test_bin} -h #{path}")
-        end
+    context 'submodule_inherit_paths' do
+      def git_artifact_submodule_inherit_paths(paths, submodule_rel_path)
+        git_artifact = Dapp::Dimg::GitArtifact.new(nil, to: '/app', branch: 'master')
+        git_artifact.submodule_inherit_paths(paths, submodule_rel_path)
+      end
 
-        def expext_container_file_link(path, link)
-          expect { check_container_symlink(path).error! }.to_not raise_error
-          expect(container_run("#{g_a_stubbed_dimg.dapp.readlink_bin} -f #{path}").stdout.strip).to eq link
-        end
+      paths = [
+        '**/*.rb', '*.txt',
+        'path', 'path2',
+        'path/**/*.exe', 'path/*.png',
+        'path2/**/*.html', 'path2/*.jpg',
+        '*th/subpath'
+      ]
 
-        symlink_file = 'symlink'
-        symlink2_file = 'symlink2'
+      it 'path' do
+        expectation = [
+          '**/*.rb', '*.rb',
+          '**/*.exe', '*.exe', '*.png',
+          'subpath'
+        ]
+        expect(git_artifact_submodule_inherit_paths(paths, 'path')).to eq expectation
+      end
 
-        before :each do
-          add_symlink_by_dev_mode('test', symlink_file)
-          apply_archive
-          expext_container_file_link(container_file_path(symlink_file), container_file_path('test'))
-        end
+      it 'missing' do
+        expectation = [
+          "**/*.rb", "*.rb"
+        ]
 
-        it 'added', test_construct: true do
-          add_symlink_by_dev_mode('test2', symlink2_file)
-          apply_patch
-          expext_container_file_link(container_file_path(symlink2_file), container_file_path('test2'))
-        end
-
-        it 'modified', test_construct: true do
-          add_symlink_by_dev_mode('test2', symlink_file)
-          apply_patch
-          expext_container_file_link(container_file_path(symlink_file), container_file_path('test2'))
-        end
-
-        it 'delete', test_construct: true do
-          rm_symlink_by_dev_mode(symlink_file)
-          apply_patch
-          expect { check_container_symlink(container_file_path(symlink_file)).error! }.to raise_error ::Mixlib::ShellOut::ShellCommandFailed
-        end
+        expect(git_artifact_submodule_inherit_paths(paths, 'missing')).to eq expectation
       end
     end
   end


### PR DESCRIPTION
> Поддержка git submodules

* git-артефакт рекурсивно пораждает артефакты submodule-й:
  * submodule-артефакт идентичен описанному в Dappfile удалённому git-репозиторию;
  * при создании дочерних артефактов преобразуются параметры базового:
    * наследуются `owner`, `group`;
    * наращивается `cwd`;
    * преобразуются `include_paths`, `exclude_paths`, `stages_dependencies`.
* добавление/исключение submodule-й не отличается от обычных файлов и директорий в git-артефакте.
  
> Тесты

* интеграционные тесты для git submodules:
  * проверка на добавление по типу submodule url: `https`, `relative_path`, `local_path`;
  * проверка вложенных submodule-й;
  * проверка submodule branch.
* юнит-тесты для git submodules
  * проверка преобразования url submodule в зависимости от репозитория, в том числе проверка `relative_path`.
  * проверка преобразования `include_paths`, `exclude_paths`, `stages_dependencies`.

> А так же

* GitRepo: получение базового `remote origin url`:
  * в случае, если `remote origin url` является путём к локальному репозиторию, будет произведён рекурсивный обход до базового `remote origin url`.
* Формализована запись mode файлов.
* Git-артефакт: branch и commit строки.
* GitRepo::Remote: кеширование по url и branch.
* GitRepo::Base: работа со вложенными git-директориями в dev-режиме.