### PR TITLE
(fix) failed to open log file ... для helm-hooks-job

### DIFF
--- a/bin/dapp
+++ b/bin/dapp
@@ -5,6 +5,8 @@
 require 'rubygems'
 require 'dapp'
 
+Thread.abort_on_exception = true
+
 begin
   begin
     begin

--- a/config/en/net_status.yml
+++ b/config/en/net_status.yml
@@ -134,6 +134,7 @@ en:
       config_context_not_found: "Context `%{context_name}` is not found in config %{config_path}"
       server_connection_refused: "Kube server `%{url}` connection refused: %{error}"
       server_error: "Kube respond with server error code %{response_http_status}, request parameters: `%{request_parameters}`, response: `%{response_raw_body}`"
+      container_stuck: "Pod's `%{pod_name}` container `%{container_name}` stuck in %{state} state: %{state_reason}: %{state_message}"
     secret:
       bad_data: "Data `%{data}` can't be decrypted: check encryption key and data!"
       key_length_too_short: "Encryption key isn't valid (required size %{required_size} bytes)!"

--- a/lib/dapp/dapp/logging/process.rb
+++ b/lib/dapp/dapp/logging/process.rb
@@ -81,7 +81,7 @@ module Dapp
           message = success_message
           start = Time.now
           with_log_indent { yield }
-        rescue Error::Default, SignalException, StandardError => _e
+        rescue Error::Base, SignalException, StandardError => _e
           message = failed_message
           raise
         ensure


### PR DESCRIPTION
Если допущена ошибка в указанной команде для entrypoint контейнера helm-hooks-job'а, то ранее выводилось сообщение:

```
failed to open log file "/var/log/pods/b757f56b-f777-11e7-8176-0800276846e1/migrate_5.log": open /var/log/pods/b757f56b-f777-11e7-8176-0800276846e1/migrate_5.log: no such file or directory
```

Теперь полный вывод в такой ситуации будет таким:

```
$ dapp kube deploy :minikube --namespace my --timeout 15
Deploy release ex-dapp-25-my                                                                                                 [RUNNING]
  Delete hooks job `migrate` ...                                                                                                  [OK] 0.05 sec
  Run helm                                                                                                                   [RUNNING]
    Watch pod's 'migrate-pqd5n' container 'migrate' log                                                                      [RUNNING]
    Watch pod's 'migrate-pqd5n' container 'migrate' log                                                                       [FAILED] 0.02 sec
Pod's `migrate-pqd5n` container `migrate` stuck in waiting state: RunContainerError: failed to start container "10754e7f897fec3f4a1bde9c4ad3ff600c4181991676426ef16a703ebcb8107d": Error response from daemon: oci runtime error: container_linux.go:262: starting container process caused "exec: \"/bin/bash\": stat /bin/bash: no such file or directory"
  Run helm                                                                                                                    [FAILED] 15.6 sec
Deploy release ex-dapp-25-my                                                                                                  [FAILED] 16.02 sec
Running time 16.14 seconds
Stacktrace dumped to /tmp/dapp-stacktrace-7cba98aa-50bb-46d8-ac28-4e481dad378d.out
>>> START STREAM
Error: UPGRADE FAILED: timed out waiting for the condition
>>> END STREAM
```

* Исправлена ошибка перехвата только Error::Default сообщений в функции log_process => теперь Error::Base
* Также немного изменен формат вывода deploy:
  * Вывод сообщения об ожидании helm, чтобы пользователю было понятно что например висит именно helm
  * Сообщения об удалении старых helm-hook'ов (dapp/recreate) перенесены под блок `Deploy release myrelease`.
