### PR TITLE
(fix) stages_cleanup_by_repo': undefined method `dimg_registry' for #<Dapp

### DIFF
--- a/lib/dapp/dimg/dapp/command/stages/cleanup_local.rb
+++ b/lib/dapp/dimg/dapp/command/stages/cleanup_local.rb
@@ -38,7 +38,7 @@ module Dapp
             def stages_cleanup_by_repo
               log_proper_repo_cache do
                 lock("#{name}.images") do
-                  registry   = dimg_registry(option_repo)
+                  registry   = registry(option_repo)
                   repo_dimgs = repo_detailed_dimgs_images(registry)
 
                   dapp_project_dangling_images_flush


### PR DESCRIPTION
Починен dapp dimg stages cleanup local.