### PR TITLE
dapp dimg stages cleanup local command: правки

### DIFF
--- a/lib/dapp/dimg/dapp/command/common.rb
+++ b/lib/dapp/dimg/dapp/command/common.rb
@@ -54,7 +54,7 @@ module Dapp
           end
 
           def update_project_images_cache(project_images)
-            dapp_project_images.delete_if { |image| project_images.include?(image) }
+            dapp_project_images.delete_if { |image| project_images.map { |i| i[:id] }.include?(image[:id]) }
           end
 
           def project_images_to_delete(project_images)

--- a/lib/dapp/dimg/dapp/command/stages/cleanup_local.rb
+++ b/lib/dapp/dimg/dapp/command/stages/cleanup_local.rb
@@ -43,8 +43,8 @@ module Dapp
 
                   # Удаление только образов старше 2ч
                   dimgstages.delete_if do |dimgstage|
-                    Time.now - dimgstage[:created_at] < 2*60*60
-                  end
+                    Time.now - dimgstage[:created_at] < 2 * 60 * 60
+                  end unless ENV['DAPP_STAGES_CLEANUP_LOCAL_DISABLED_DATE_POLICY']
 
                   remove_project_images(dimgstages)
                 end

--- a/lib/dapp/dimg/dapp/command/stages/cleanup_local.rb
+++ b/lib/dapp/dimg/dapp/command/stages/cleanup_local.rb
@@ -19,7 +19,11 @@ module Dapp
             def proper_cache
               log_proper_cache do
                 lock("#{name}.images") do
-                  remove_project_images(dapp_project_dimgstages - actual_cache_project_dimgstages)
+                  remove_project_images begin
+                    dapp_project_dimgstages.select do |image|
+                      !actual_cache_project_dimgstages.map { |dimgstage| dimgstage[:id] }.include?(image[:id])
+                    end
+                  end
                 end
               end
             end


### PR DESCRIPTION
*  dapp dimg stages cleanup local command: фикс очистки с опцией `--proper-cache-version`;
*  dapp dimg stages cleanup local command: debug переменная окружения 
   * `DAPP_STAGES_CLEANUP_LOCAL_DISABLED_DATE_POLICY` для отключения игнорирования образов младше двух часов при очистке с опцией `--improper-repo-cache`.