### PR TITLE
Config: обработка артефактов

### DIFF
--- a/config/en/net_status.yml
+++ b/config/en/net_status.yml
@@ -80,7 +80,7 @@ en:
       stage_artifact_double_associate: "Can't use `%{stage}` stage for artifact; already used in `%{conflict_stage}` stage!"
       stage_artifact_not_supported_associated_stage: "Bad artifact stage `%{stage}`!"
       git_artifact_remote_branch_with_commit: "Remote git repo: use `commit` or `branch` directive!"
-      artifact_conflict: "Conflict between artifacts paths!"
+      artifact_conflict: "Conflict between artifacts!\n\n%{dappfile_context}"
       scratch_unsupported_directive: "Scratch dimg has unsupported directive `%{directive}`!"
       scratch_artifact_required: "Scratch dimg without artifacts!"
       scratch_artifact_associated: "Scratch artifact can't be associated: not expected `before`/`after` attribute!"

--- a/lib/dapp/dimg/config/directive/artifact_dimg.rb
+++ b/lib/dapp/dimg/config/directive/artifact_dimg.rb
@@ -5,13 +5,6 @@ module Dapp
         class ArtifactDimg < Dimg
           def validate_scratch!
           end
-
-          def validate_artifacts_artifacts!
-          end
-
-          def validated_artifacts
-            _git_artifact._local + _git_artifact._remote
-          end
         end
       end
     end

--- a/lib/dapp/dimg/config/directive/dimg/instance_methods.rb
+++ b/lib/dapp/dimg/config/directive/dimg/instance_methods.rb
@@ -136,6 +136,7 @@ module Dapp
 
             def artifacts_after_parsing!
               _artifacts_auto_excluding!
+              _artifact.map(&:_config).each(&:artifacts_after_parsing!)
             end
 
             protected

--- a/lib/dapp/dimg/config/directive/dimg/validation.rb
+++ b/lib/dapp/dimg/config/directive/dimg/validation.rb
@@ -125,12 +125,14 @@ module Dapp
             end
 
             def validate_artifact_path!(verifiable_artifact, potential_conflicts)
-              potential_conflicts.all? do |path|
-                loop do
-                  break if verifiable_artifact[:exclude_paths].include?(path) || ((path = File.dirname(path)) == '.')
+              raise ::Dapp::Error::Config, code: :artifact_conflict unless begin
+                potential_conflicts.all? do |path|
+                  loop do
+                    break if verifiable_artifact[:exclude_paths].include?(path) || ((path = File.dirname(path)) == '.')
+                  end
+                  verifiable_artifact[:exclude_paths].include?(path)
                 end
-                verifiable_artifact[:exclude_paths].include?(path)
-              end.tap { |res| res || raise(::Dapp::Error::Config, code: :artifact_conflict) }
+              end
             end
 
             def _associated_artifacts

--- a/lib/dapp/dimg/config/directive/dimg/validation.rb
+++ b/lib/dapp/dimg/config/directive/dimg/validation.rb
@@ -71,10 +71,37 @@ module Dapp
                 verifiable_artifact = artifacts.shift
                 artifacts.select { |a| a[:to] == verifiable_artifact[:to] }.each do |artifact|
                   next if verifiable_artifact[:index] == artifact[:index]
-                  validate_artifact!(verifiable_artifact, artifact)
-                  validate_artifact!(artifact, verifiable_artifact)
+                  begin
+                    validate_artifact!(verifiable_artifact, artifact)
+                    validate_artifact!(artifact, verifiable_artifact)
+                  rescue ::Dapp::Error::Config => e
+                    conflict_between_artifacts!(artifact, verifiable_artifact) if e.net_status[:code] == :artifact_conflict
+                    raise
+                  end
                 end
               end
+            end
+
+            def conflict_between_artifacts!(*formatted_artifacts)
+              artifacts = formatted_artifacts.flatten.map { |formatted_artifact| formatted_artifact[:related_artifact] }
+              dappfile_context = artifacts.map do |artifact|
+                artifact_directive = []
+                artifact_directive << begin
+                  if artifact.is_a? Artifact::Export
+                    "artifact.export('#{artifact._cwd}') do"
+                  else
+                    "git#{"('#{artifact._url}')" if artifact.respond_to?(:_url)}.add('#{artifact._cwd}') do"
+                  end
+                end
+                [:include_paths, :exclude_paths].each do |directive|
+                  next if (paths = artifact.send("_#{directive}")).empty?
+                  artifact_directive << "  #{directive} '#{paths.join("', '")}'"
+                end
+                artifact_directive << "  to '#{artifact._to}'"
+                artifact_directive << 'end'
+                artifact_directive.join("\n")
+              end.join("\n\n")
+              raise ::Dapp::Error::Config, code: :artifact_conflict, data: { dappfile_context: dappfile_context }
             end
 
             def validate_artifact_format(artifacts)
@@ -104,7 +131,8 @@ module Dapp
                   index: artifacts.index(a),
                   to: to,
                   include_paths: include_paths,
-                  exclude_paths: exclude_paths
+                  exclude_paths: exclude_paths,
+                  related_artifact: a
                 }
               end
             end

--- a/lib/dapp/dimg/config/directive/dimg/validation.rb
+++ b/lib/dapp/dimg/config/directive/dimg/validation.rb
@@ -113,8 +113,15 @@ module Dapp
               verifiable_artifact[:include_paths].each do |verifiable_path|
                 potential_conflicts = artifact[:include_paths].select { |path| path.start_with?(verifiable_path) }
                 validate_artifact_path!(verifiable_artifact, potential_conflicts)
-              end.empty? && verifiable_artifact[:exclude_paths].empty? && raise(::Dapp::Error::Config, code: :artifact_conflict)
-              validate_artifact_path!(verifiable_artifact, artifact[:include_paths]) if verifiable_artifact[:include_paths].empty?
+              end
+
+              if verifiable_artifact[:include_paths].empty?
+                if artifact[:include_paths].empty? || verifiable_artifact[:exclude_paths].empty?
+                  raise ::Dapp::Error::Config, code: :artifact_conflict
+                else
+                  validate_artifact_path!(verifiable_artifact, artifact[:include_paths])
+                end
+              end
             end
 
             def validate_artifact_path!(verifiable_artifact, potential_conflicts)


### PR DESCRIPTION
* Config: добавлен auto excluding для артефактов артефактов.
* Config: фикс валидации путей артефактов:
  * не учитывался случай, когда артефакты:
    * добавляются по одному и тому же пути;
    * имеют `exclude_paths`;
    * не имеют `include_paths`.
* Config: рефакторинг
* Config: при конфликте артефактов генерируются соответствующие директивы.
```
Conflict between artifacts!

git('https://github.com/group/project.git').add('/directory') do
  exclude_paths 'examples'
  to '/app'
end

artifact.export('/app') do
  to '/app'
end
```