### PR TITLE
Fix: отказ от кеширования GitRepo::Remote по url и branch

### DIFF
--- a/lib/dapp/dimg/dimg/git_artifact.rb
+++ b/lib/dapp/dimg/dimg/git_artifact.rb
@@ -18,7 +18,7 @@ module Dapp
         def remote_git_artifacts
           @remote_git_artifact_list ||= [].tap do |artifacts|
             Array(config._git_artifact._remote).each do |ga_config|
-              repo = GitRepo::Remote.get_or_init(self, ga_config._name, url: ga_config._url, branch: ga_config._branch)
+              repo = GitRepo::Remote.new(self, ga_config._name, url: ga_config._url).tap { |r| r.fetch!(ga_config._branch) }
               artifacts.concat(generate_git_artifacts(repo, **ga_config._artifact_options))
             end
           end

--- a/lib/dapp/dimg/git_artifact.rb
+++ b/lib/dapp/dimg/git_artifact.rb
@@ -43,9 +43,8 @@ module Dapp
       def submodule_artifact(submodule_params)
         submodule_rel_path = submodule_params[:path]
         submodule_repo     = begin
-          GitRepo::Remote.get_or_init(repo.dimg, submodule_rel_path,
-                                      url: submodule_url(submodule_params[:url]),
-                                      branch: submodule_params[:branch])
+          GitRepo::Remote.new(repo.dimg, submodule_rel_path,
+                              url: submodule_url(submodule_params[:url])).tap { |r| r.fetch!(submodule_params[:branch]) }
         rescue Rugged::InvalidError => e
           raise Error::Rugged, code: :incorrect_gitmodules_file, data: { error: e.message }
         end

--- a/lib/dapp/dimg/git_repo/remote.rb
+++ b/lib/dapp/dimg/git_repo/remote.rb
@@ -4,11 +4,6 @@ module Dapp
       class Remote < Base
         CACHE_VERSION = 1
 
-        def self.get_or_init(dimg, name, url:, branch:)
-          key = [url, branch]
-          (@repos ||= {})[key] ||= new(dimg, name, url: url).tap { |repo| repo.fetch!(branch) }
-        end
-
         attr_reader :url
 
         def initialize(dimg, name, url:)


### PR DESCRIPTION
* при инициализации git-артефактов в dimg и артефакт-dimg мог использоваться один и тот же GitRepo::Remote;
* использовался объект GitRepo::Remote, который связан с dimg, объявленным при первом обращении;
* это приводило к ошибкам при наложении патчей и создании артефактов (из-за несоответствующих tmp-путей у dimg-ей).