### PR TITLE
(fix) Иногда не выводятся логи для dapp/watch-logs

### DIFF
--- a/config/en/net_status.yml
+++ b/config/en/net_status.yml
@@ -44,6 +44,7 @@ en:
       expected_only_one_tag: 'Expected only one tag (`%{tags}`)!'
       kube_deploy_timeout: "Deploy timeout!"
       kube_connect_timeout: "Connect timeout when connecting to kube API."
+      kube_helm_failed: "Helm failed: %{output}"
     dapp:
       no_such_dimg: "No such dimg: `%{dimgs_patterns}`!"
       no_such_app: "No such app: `%{apps_patterns}`!"
@@ -136,6 +137,8 @@ en:
       server_connection_refused: "Kube server `%{url}` connection refused: %{error}"
       server_error: "Kube respond with server error code %{response_http_status}, request parameters: `%{request_parameters}`, response: `%{response_raw_body}`"
       container_stuck: "Pod's `%{pod_name}` container `%{container_name}` stuck in %{state} state: %{state_reason}: %{state_message}"
+      bad_image: "Pod `%{pod_name}` bad image: %{reason}: %{message}"
+      container_crash: "Pod's `%{pod_name}` container crashed: %{reason}: %{message}"
     secret:
       bad_data: "Data `%{data}` can't be decrypted: check encryption key and data!"
       key_length_too_short: "Encryption key isn't valid (required size %{required_size} bytes)!"

--- a/lib/dapp/kube/helm/release.rb
+++ b/lib/dapp/kube/helm/release.rb
@@ -49,7 +49,7 @@ module Dapp
         end.to_h
       end
 
-      def deploy!
+      def helm_upgrade!
         args = [
           name, chart_path, additional_values_options,
           set_options, upgrade_extra_options
@@ -57,7 +57,9 @@ module Dapp
 
         dapp.kubernetes.create_namespace!(namespace) unless dapp.kubernetes.namespace?(namespace)
 
-        dapp.shellout! "helm upgrade #{args.join(' ')}", verbose: true
+        cmd = dapp.shellout "helm upgrade #{args.join(' ')}"
+
+        return cmd
       end
 
       def templates

--- a/lib/dapp/kube/kubernetes/client/resource/pod.rb
+++ b/lib/dapp/kube/kubernetes/client/resource/pod.rb
@@ -2,6 +2,20 @@ module Dapp
   module Kube
     module Kubernetes::Client::Resource
       class Pod < Base
+        # Returns:
+        #   nil: no such condition yet
+        #   "True" string: ready
+        #   "False" string: not ready
+        def ready_condition_status
+          rd = self.ready_condition
+          return nil unless rd
+          return rd['status']
+        end
+
+        def ready_condition
+          status.fetch('conditions', {}).find {|condition| condition['type'] == 'Ready'}
+        end
+
         def container_id(container_name)
           container_status = spec.fetch('status', {})
             .fetch('containerStatuses')

--- a/lib/dapp/kube/kubernetes/manager/container.rb
+++ b/lib/dapp/kube/kubernetes/manager/container.rb
@@ -18,7 +18,7 @@ module Dapp
           _, container_state_data = pod.container_state(name)
           return if @processed_containers_ids.include? container_state_data['containerID']
 
-          pod_manager.wait_till_running!
+          pod_manager.wait_till_launched!
 
           pod = Kubernetes::Client::Resource::Pod.new(dapp.kubernetes.pod(pod_manager.name))
           container_state, container_state_data = pod.container_state(name)

--- a/lib/dapp/kube/kubernetes/manager/pod.rb
+++ b/lib/dapp/kube/kubernetes/manager/pod.rb
@@ -9,10 +9,44 @@ module Dapp
           end
         end
 
-        def wait_till_running!
+        def check_readiness_condition_if_available!(pod)
+          return if [nil, "True"].include? pod.ready_condition_status
+
+          if pod.ready_condition['reason'] == 'ContainersNotReady'
+            [*Array(pod.status["initContainerStatuses"]), *Array(pod.status["containerStatuses"])].each do |container_status|
+              next if container_status['ready']
+
+              waiting_reason = container_status.fetch('state', {}).fetch('waiting', {}).fetch('reason', nil)
+              case waiting_reason
+              when 'ImagePullBackOff', 'ErrImagePull'
+                raise Kubernetes::Error::Default,
+                  code: :bad_image,
+                  data: {pod_name: pod.name,
+                         reason: waiting_reason,
+                         message: container_status['state']['waiting']['message']}
+              when 'CrashLoopBackOff'
+                raise Kubernetes::Error::Default,
+                  code: :container_crash,
+                  data: {pod_name: pod.name,
+                         reason: waiting_reason,
+                         message: container_status['state']['waiting']['message']}
+              end
+            end
+          else
+            dapp.with_log_indent do
+              dapp.log_warning("#{dapp.log_time}Unknown pod readiness condition reason '#{pod.ready_condition['reason']}': #{pod.ready_condition}", stream: dapp.service_stream)
+            end
+          end
+        end
+
+        def wait_till_launched!
           loop do
             pod = Kubernetes::Client::Resource::Pod.new(dapp.kubernetes.pod(name))
-            break if pod.phase == 'Running'
+
+            break if pod.phase != "Pending"
+
+            check_readiness_condition_if_available!(pod)
+
             sleep 0.1
           end
         end


### PR DESCRIPTION
Зависело от того, насколько быстро выполняется хук. Если "очень быстро", то dapp ничего не выводил.

Также:
* Улучшена синхронизация вывода helm stdout/stderr в процессе деплоя с выводом логов: все выводится строго по-очереди, сначал watch-logs, затем helm output.
* User-friendly ошибки при возникновении ImagePullBackOff, ErrImagePull, CrashLoopBackOff для отслеживания Deployment и Job'ов с dapp/watch-logs.
* В случае, если под еще не перешел в кондицию "Ready", при каждом перевыкате через dapp будут выводится все логи всех контейнеров пода для удобства пользователя. Ранее эти логи при повторном запуске не выводились, надо было лезть на сервер. Для ready-подов так не делается, чтобы не выводить при каждом последующем выкате все предыдущие логи пода, если он не был пересоздан, вместо этого выводятся только логи с момента запуска деплоя.