### PR TITLE
(fix build) multiple-value uuid.NewV4() in single-value context

### DIFF
--- a/go-build.sh
+++ b/go-build.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+set -e
+
 go install github.com/flant/dapp/cmd/dappfile-yml

--- a/go-get.sh
+++ b/go-get.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
+set -e
+
+go get -v github.com/satori/go.uuid
+git -C ../../satori/go.uuid/ checkout v1.2.0
+
 go get -v github.com/flant/dapp/cmd/dappfile-yml


### PR DESCRIPTION
Use go.uuid v1.2.0 in go-get.sh
