### PR TITLE
(fix) Could not obtain lock for `...` within 300 seconds!

### DIFF
--- a/lib/dapp/dapp/deps/base.rb
+++ b/lib/dapp/dapp/deps/base.rb
@@ -12,7 +12,7 @@ module Dapp
           @base_container ||= begin
             is_container_exist = proc{shellout("#{host_docker} inspect #{base_container_name}").exitstatus.zero?}
             if !is_container_exist.call
-              lock("dappdeps.container.#{base_container_name}", default_timeout: 120) do
+              lock("dappdeps.container.#{base_container_name}", default_timeout: 600) do
                 if !is_container_exist.call
                   log_secondary_process(t(code: 'process.base_container_creating', data: {name: base_container_name}), short: true) do
                     shellout!(

--- a/lib/dapp/dapp/deps/gitartifact.rb
+++ b/lib/dapp/dapp/deps/gitartifact.rb
@@ -12,7 +12,7 @@ module Dapp
           @gitartifact_container ||= begin
             is_container_exist = proc{shellout("#{host_docker} inspect #{gitartifact_container_name}").exitstatus.zero?}
             if !is_container_exist.call
-              lock("dappdeps.container.#{gitartifact_container_name}", default_timeout: 120) do
+              lock("dappdeps.container.#{gitartifact_container_name}", default_timeout: 600) do
                 if !is_container_exist.call
                   log_secondary_process(t(code: 'process.gitartifact_container_creating', data: {name: gitartifact_container_name}), short: true) do
                     shellout!(

--- a/lib/dapp/dapp/deps/toolchain.rb
+++ b/lib/dapp/dapp/deps/toolchain.rb
@@ -12,7 +12,7 @@ module Dapp
           @toolchain_container ||= begin
             is_container_exist = proc {shellout("#{host_docker} inspect #{toolchain_container_name}").exitstatus.zero?}
             if !is_container_exist.call
-              lock("dappdeps.container.#{toolchain_container_name}", default_timeout: 300) do
+              lock("dappdeps.container.#{toolchain_container_name}", default_timeout: 600) do
                 if !is_container_exist.call
                   log_secondary_process(t(code: 'process.toolchain_container_creating', data: {name: toolchain_container_name}), short: true) do
                     shellout!(

--- a/lib/dapp/dapp/lock.rb
+++ b/lib/dapp/dapp/lock.rb
@@ -10,7 +10,8 @@ module Dapp
         @_locks[name] ||= ::Dapp::Dimg::Lock::File.new(locks_dir, name)
       end
 
-      def lock(name, *_args, default_timeout: 300, **kwargs, &blk)
+      # default_timeout 24 hours
+      def lock(name, *_args, default_timeout: 86400, **kwargs, &blk)
         if dry_run?
           yield if block_given?
         else

--- a/lib/dapp/dimg/builder/chef.rb
+++ b/lib/dapp/dimg/builder/chef.rb
@@ -64,7 +64,7 @@ module Dapp
         @chefdk_container ||= begin
           is_container_exist = proc{dimg.dapp.shellout("#{dimg.dapp.host_docker} inspect #{chefdk_container_name}").exitstatus.zero?}
           if !is_container_exist.call
-            dimg.dapp.lock("dappdeps.container.#{chefdk_container_name}", default_timeout: 120) do
+            dimg.dapp.lock("dappdeps.container.#{chefdk_container_name}", default_timeout: 600) do
               if !is_container_exist.call
                 dimg.dapp.log_secondary_process(dimg.dapp.t(code: 'process.chefdk_container_creating', data: {name: chefdk_container_name}), short: true) do
                   dimg.dapp.shellout!(

--- a/lib/dapp/dimg/builder/chef/cookbook.rb
+++ b/lib/dapp/dimg/builder/chef/cookbook.rb
@@ -66,7 +66,7 @@ module Dapp
       end
 
       def vendor_path
-        builder.dimg.dapp.lock(_vendor_lock_name, default_timeout: 120) do
+        builder.dimg.dapp.lock(_vendor_lock_name, default_timeout: 600) do
           vendor! unless _vendor_path.join('.created_at').exist?
         end
         _vendor_path

--- a/lib/dapp/dimg/git_repo/remote.rb
+++ b/lib/dapp/dimg/git_repo/remote.rb
@@ -49,7 +49,7 @@ module Dapp
         end
 
         def _with_lock(&blk)
-          dapp.lock("remote_git_artifact.#{name}", default_timeout: 120, &blk)
+          dapp.lock("remote_git_artifact.#{name}", default_timeout: 600, &blk)
         end
 
         def _rugged_credentials


### PR DESCRIPTION
Changed default lock timeout:
* For stages (affects build & push): 24 hours (was 5 minutes)
* For dappdeps downloading: 10 minutes (was 2-5 minutes)
* For git fetch operations: 10 minutes (was 2 minutes)
* For berks deps installation: 10 minutes (was 2 minutes)
