### PR TITLE
(fix) /tmp/dapp-<date>-<random> dirs cleanup

### DIFF
--- a/lib/dapp/dapp.rb
+++ b/lib/dapp/dapp.rb
@@ -35,6 +35,8 @@ module Dapp
       Logging::I18n.initialize
       validate_config_options!
       Logging::Paint.initialize(option_color)
+
+      @_call_before_terminate = []
     end
 
     def options
@@ -120,6 +122,7 @@ module Dapp
     end
 
     def terminate
+      @_call_before_terminate.each {|on_terminate| on_terminate.call(self)}
       FileUtils.rmtree(host_docker_tmp_config_dir)
     end
 

--- a/lib/dapp/dimg/dapp/dimg.rb
+++ b/lib/dapp/dimg/dapp/dimg.rb
@@ -9,6 +9,10 @@ module Dapp
         def artifact_dimg(config:, **kwargs)
           (@artifacts_dimgs ||= {})[config._name] ||= ::Dapp::Dimg::Artifact.new(config: config, dapp: self, **kwargs)
         end
+
+        def _terminate_dimg_on_terminate(dimg)
+          @_call_before_terminate << proc{dimg.terminate}
+        end
       end # Dimg
     end # Dapp
   end # Dimg

--- a/lib/dapp/dimg/dimg.rb
+++ b/lib/dapp/dimg/dimg.rb
@@ -20,7 +20,13 @@ module Dapp
         @ignore_git_fetch = ignore_git_fetch
         @should_be_built = should_be_built
 
+        @dapp._terminate_dimg_on_terminate(self)
+
         raise Error::Dimg, code: :dimg_not_built if should_be_built?
+      end
+
+      def terminate
+        cleanup_tmp
       end
 
       def build!
@@ -36,8 +42,6 @@ module Dapp
             end
           end
         end
-      ensure
-        cleanup_tmp
       end
 
       def after_stages_build!
@@ -196,8 +200,6 @@ module Dapp
           cmd << " rm -rf #{tmp_path}"
         end
         dapp.shellout! cmd
-
-        artifacts.each(&:cleanup_tmp)
       end
 
       def stage_should_be_introspected?(name)

--- a/spec/spec_helper/dimg.rb
+++ b/spec/spec_helper/dimg.rb
@@ -132,11 +132,21 @@ module SpecHelper
     end
 
     def empty_dimg
-      Dapp::Dimg::Dimg.new(dapp: nil, config: openstruct_config)
+      Dapp::Dimg::Dimg.new(dapp: dapp_for_empty_dimg, config: openstruct_config)
     end
 
     def empty_artifact
-      Dapp::Dimg::Artifact.new(dapp: nil, config: openstruct_config)
+      Dapp::Dimg::Artifact.new(dapp: dapp_for_empty_dimg, config: openstruct_config)
     end
+
+    def dapp_for_empty_dimg
+      instance_double(Dapp::Dapp).tap do |instance|
+        allow(instance).to receive(:name) { File.basename(Dir.getwd) }
+        allow(instance).to receive(:path) { Dir.getwd }
+        allow(instance).to receive(:log_warning)
+        allow(instance).to receive(:_terminate_dimg_on_terminate)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
`/tmp/dapp-<date>-<random>` was not cleaned up after `dimg push` & `kube deploy` commands.

Now cleanup is durably called on every dapp termination.