### PR TITLE
(fix) dapp kube deploy: Expected only one tag

### DIFF
--- a/lib/dapp/dapp/option_tags.rb
+++ b/lib/dapp/dapp/option_tags.rb
@@ -69,11 +69,17 @@ module Dapp
 
         {}.tap do |tags_by_scheme|
           if ENV['GITLAB_CI']
-            tags_by_scheme[:git_branch] = [ENV['CI_BUILD_REF_NAME']]
-            tags_by_scheme[:git_tag]    = [ENV['CI_BUILD_TAG']]
+            if ENV['CI_BUILD_TAG']
+              tags_by_scheme[:git_tag] = [ENV['CI_BUILD_TAG']]
+            elsif ENV['CI_BUILD_REF_NAME']
+              tags_by_scheme[:git_branch] = [ENV['CI_BUILD_REF_NAME']]
+            end
           elsif ENV['TRAVIS']
-            tags_by_scheme[:git_branch] = [ENV['TRAVIS_BRANCH']]
-            tags_by_scheme[:git_tag]    = [ENV['TRAVIS_TAG']]
+            if ENV['TRAVIS_TAG']
+              tags_by_scheme[:git_tag]    = [ENV['TRAVIS_TAG']]
+            elsif ENV['TRAVIS_BRANCH']
+              tags_by_scheme[:git_branch] = [ENV['TRAVIS_BRANCH']]
+            end
           else
             raise Error::Dapp, code: :ci_environment_required
           end


### PR DESCRIPTION
--tag-ci was broken when CI_BUILD_TAG and CI_BUILD_REF_NAME available at the same time.
--tag-ci will use only one of tag-scheme or branch-scheme now.