### PR TITLE
Игнорирование пустых git-артефактов

### DIFF
--- a/lib/dapp/dimg/dimg/git_artifact.rb
+++ b/lib/dapp/dimg/dimg/git_artifact.rb
@@ -32,6 +32,8 @@ module Dapp
           [].tap do |artifacts|
             artifacts << (artifact = ::Dapp::Dimg::GitArtifact.new(repo, self, **git_artifact_options))
             artifacts.concat(generate_git_embedded_artifacts(artifact))
+          end.select do |artifact|
+            !artifact.empty?
           end
         end
 

--- a/lib/dapp/dimg/git_artifact.rb
+++ b/lib/dapp/dimg/git_artifact.rb
@@ -290,6 +290,10 @@ module Dapp
         any_changes?(*patch_stage_commits(stage))
       end
 
+      def empty?
+        repo_entries(latest_commit).empty?
+      end
+
       protected
 
       def hexdigest(*args)


### PR DESCRIPTION
* git-артефакт считается пустым, если в репозитории отсутствуют файлы удовлетворяющие конфигурации;
* dev-режим не работает в пустых git-артефактах, т.к. необходим тип (:directory, :file), который определяется исходя из существующих в репозитории файлов.