### PR TITLE
GITLAB: docker login перед pull-ом базового образа

### DIFF
--- a/lib/dapp/dapp.rb
+++ b/lib/dapp/dapp.rb
@@ -140,13 +140,14 @@ module Dapp
 
     def try_host_docker_login
       return unless option_repo
-
       validate_repo_name!(option_repo)
+      host_docker_login(option_repo)
+    end
 
-      if self.class.options_with_docker_credentials?
-        username, password = self.class.docker_credentials
-        shellout!("#{host_docker} login -u '#{username}' -p '#{password}' '#{option_repo}'")
-      end
+    def host_docker_login(repo)
+      return unless self.class.options_with_docker_credentials?
+      username, password = self.class.docker_credentials
+      shellout!("#{host_docker} login -u '#{username}' -p '#{password}' '#{repo}'")
     end
 
     class << self

--- a/lib/dapp/dimg/build/stage/from.rb
+++ b/lib/dapp/dimg/build/stage/from.rb
@@ -10,10 +10,20 @@ module Dapp
           protected
 
           def prepare_image
+            try_host_docker_login
             from_image.pull!
             raise Error::Build, code: :from_image_not_found, data: { name: from_image_name } unless from_image.tagged?
             add_cleanup_mounts_dirs_command
             super
+          end
+
+          def try_host_docker_login
+            return unless registry_from_image_name?
+            dimg.dapp.host_docker_login(ENV['CI_REGISTRY'])
+          end
+
+          def registry_from_image_name?
+            ENV['CI_REGISTRY'] && from_image_name.start_with?(ENV['CI_REGISTRY'])
           end
 
           def add_cleanup_mounts_dirs_command


### PR DESCRIPTION
* попытка авторизации выполняется, если имя базового образа dimg-а, `docker.from`, начинается c `$CI_REGISTRY`.