### PR TITLE
(yaml) Do not double-print cfg when error is in yaml-doc toplevel key

### DIFF
--- a/pkg/config/common.go
+++ b/pkg/config/common.go
@@ -18,14 +18,18 @@ type Doc struct {
 	RenderFilePath string
 }
 
-func CheckOverflow(m map[string]interface{}, config interface{}, doc *Doc) error {
+func CheckOverflow(m map[string]interface{}, configSection interface{}, doc *Doc) error {
 	if len(m) > 0 {
 		var keys []string
 		for k := range m {
 			keys = append(keys, k)
 		}
 
-		return fmt.Errorf("Unknown fields: `%s`!\n\n%s\n%s", strings.Join(keys, "`, `"), DumpConfigSection(config), DumpConfigDoc(doc))
+		if configSection == nil {
+			return fmt.Errorf("Unknown fields: `%s`!\n\n%s", strings.Join(keys, "`, `"), DumpConfigDoc(doc))
+		} else {
+			return fmt.Errorf("Unknown fields: `%s`!\n\n%s\n%s", strings.Join(keys, "`, `"), DumpConfigSection(configSection), DumpConfigDoc(doc))
+		}
 	}
 	return nil
 }

--- a/pkg/config/raw_dimg.go
+++ b/pkg/config/raw_dimg.go
@@ -51,7 +51,7 @@ func (c *RawDimg) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	if err := CheckOverflow(c.UnsupportedAttributes, c, c.Doc); err != nil {
+	if err := CheckOverflow(c.UnsupportedAttributes, nil, c.Doc); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Unknown field `field` errors fix.