### PR TITLE
dapp dimg stages cleanup local: чистка dangling образов и контейнеров

### DIFF
--- a/lib/dapp/dimg/dapp/command/cleanup.rb
+++ b/lib/dapp/dimg/dapp/command/cleanup.rb
@@ -5,8 +5,8 @@ module Dapp
         module Cleanup
           def cleanup
             log_step_with_indent(:cleanup) do
-              dapp_containers_flush
-              dapp_dangling_images_flush
+              dapp_containers_flush_by_label('dapp')
+              dapp_dangling_images_flush_by_label('dapp')
             end
           end
         end

--- a/lib/dapp/dimg/dapp/command/common.rb
+++ b/lib/dapp/dimg/dapp/command/common.rb
@@ -66,12 +66,16 @@ module Dapp
             project_images.map { |image| image[:dangling] ? image[:id] : image[:name] }
           end
 
-          def dapp_containers_flush
-            remove_containers_by_query(%(#{host_docker} ps -a -f "label=dapp" -q --no-trunc))
+          def dapp_containers_flush_by_label(label)
+            log_proper_containers do
+              remove_containers_by_query(%(#{host_docker} ps -a -f "label=#{label}" -q --no-trunc))
+            end
           end
 
-          def dapp_dangling_images_flush
-            remove_images_by_query(%(#{host_docker} images -f "dangling=true" -f "label=dapp" -q --no-trunc))
+          def dapp_dangling_images_flush_by_label(label)
+            log_proper_flush_dangling_images do
+              remove_images_by_query(%(#{host_docker} images -f "dangling=true" -f "label=#{label}" -q --no-trunc))
+            end
           end
 
           def dapp_tagless_images_flush
@@ -175,6 +179,14 @@ module Dapp
 
           def log_proper_repo_cache(&blk)
             log_step_with_indent(:'proper repo cache', &blk)
+          end
+
+          def log_proper_containers(&blk)
+            log_step_with_indent(:'proper containers', &blk)
+          end
+
+          def log_proper_flush_dangling_images(&blk)
+            log_step_with_indent(:'proper dangling', &blk)
           end
 
           def push_format(dimg_name)

--- a/lib/dapp/dimg/dapp/command/mrproper.rb
+++ b/lib/dapp/dimg/dapp/command/mrproper.rb
@@ -16,7 +16,7 @@ module Dapp
                 proper_cache_version
               end
 
-              dapp_dangling_images_flush
+              dapp_dangling_images_flush_by_label('dapp')
               dapp_tagless_images_flush
             end
           end
@@ -52,16 +52,14 @@ module Dapp
           end
 
           def flush_by_label(label)
-            log_step_with_indent(:containers) { dapp_containers_flush_by_label(label) }
-            log_step_with_indent(:images) { dapp_images_flush_by_label(label) }
-          end
-
-          def dapp_containers_flush_by_label(label)
-            remove_containers_by_query(%(#{host_docker} ps -a -f "label=dapp" -f "label=#{label}" -q --no-trunc))
+            dapp_containers_flush_by_label(label)
+            dapp_images_flush_by_label(label)
           end
 
           def dapp_images_flush_by_label(label)
-            remove_images(dapp_images_names_by_label(label))
+            log_step_with_indent('proper images') do
+              remove_images(dapp_images_names_by_label(label))
+            end
           end
 
           def proper_cache_version

--- a/lib/dapp/dimg/dapp/command/stages/cleanup_local.rb
+++ b/lib/dapp/dimg/dapp/command/stages/cleanup_local.rb
@@ -11,6 +11,9 @@ module Dapp
                 proper_cache           if proper_cache_version?
                 stages_cleanup_by_repo if proper_repo_cache?
                 proper_git_commit      if proper_git_commit?
+
+                dapp_containers_flush_by_label("dapp=#{name}")
+                dapp_dangling_images_flush_by_label("dapp=#{name}")
               end
             end
 

--- a/lib/dapp/dimg/dimg.rb
+++ b/lib/dapp/dimg/dimg.rb
@@ -198,6 +198,7 @@ module Dapp
         cmd = "".tap do |cmd|
           cmd << "#{dapp.host_docker} run --rm"
           cmd << " --volume #{dapp.tmp_base_dir}:#{dapp.tmp_base_dir}"
+          cmd << " --label dapp=#{dapp.name}"
           cmd << " alpine:3.6"
           cmd << " rm -rf #{tmp_path}"
         end


### PR DESCRIPTION
* dangling образы могут оставаться при неуспешных сборках по аналогии с docker build;
* контейнеры могут оставаться при некорректном завершении сборки;
* чистка выполняется по умолчанию;
* добавлен label `dapp=#{project_name}` в запускаемых контейнер, отвечающего за очистку временной директории приложения проекта.