### PR TITLE
(yaml) Remove ``` from yml errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.vendor
 /Gemfile.lock
 /.vscode
+.dappfile.render.yml
+.dappfile.render.yaml

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -7,30 +7,38 @@ import (
 	"gopkg.in/flant/yaml.v2"
 )
 
+func getLines(data []byte) [][]byte {
+	contentLines := bytes.Split(data, []byte("\n"))
+	if string(contentLines[len(contentLines)-1]) == "" {
+		contentLines = contentLines[0 : len(contentLines)-1]
+	}
+	return contentLines
+}
+
 func DumpConfigSection(config interface{}) string {
-	res := "```\n"
 	d, err := yaml.Marshal(config)
 	if err != nil {
 		return ""
 	}
-	res += string(d)
-	res += "```\n"
+
+	contentLines := getLines(d)
+
+	res := ""
+	for _, lineBytes := range contentLines {
+		res += fmt.Sprintf("    %s\n", string(lineBytes))
+	}
 
 	return res
 }
 
 func DumpConfigDoc(doc *Doc) string {
-	contentLines := bytes.Split(doc.Content, []byte("\n"))
-	if string(contentLines[len(contentLines)-1]) == "" {
-		contentLines = contentLines[0 : len(contentLines)-1]
-	}
+	contentLines := getLines(doc.Content)
 
 	res := fmt.Sprintf("%s\n\n", doc.RenderFilePath)
-	res += "```\n"
 	for lineNum, lineBytes := range contentLines {
 		res += fmt.Sprintf("%6d  %s\n", doc.Line+lineNum+1, string(lineBytes))
 	}
-	res += "```\n"
+	res += "\n"
 
 	return res
 }

--- a/playground/test2/dappfile.yml
+++ b/playground/test2/dappfile.yml
@@ -1,10 +1,13 @@
+dimg: asdf
+from: centos:7
+---
 dimg: hello
 from: ubuntu:16.04
 ansible:
   beforeInstall:
     - debug: msg='Start install'
     - debug: msg='Hello install'
-    - file: path=/etc mode=0777
+    #- file: path=/etc mode=0777
     #- copy:
         #src: /bin/sh
         #dest: /bin/sh.orig
@@ -12,5 +15,6 @@ ansible:
     - apk:
         name: curl
         update_cache: yes
+      tag: aloha
   setup:
     - command: ls -la /bin


### PR DESCRIPTION
Blocks are indented by space-only to allow posting dapp errors to slack inside block:

```
Bad dappfile /home/distorhead/go-workspace/src/github.com/flant/dapp/playground/test2/dappfile.yml: Unsupported ansible task!

        file: path=/etc mode=0777

Supported modules list:
* command
* shell
* copy
* debug
* apk
* apt
* apt_key
* apt_repository
* yum
* yum_repository

/home/distorhead/go-workspace/src/github.com/flant/dapp/playground/test2/.dappfile.render.yml

     4  dimg: hello
     5  from: ubuntu:16.04
     6  ansible:
     7    beforeInstall:
     8      - debug: msg='Start install'
     9      - debug: msg='Hello install'
    10      - file: path=/etc mode=0777
    11      #- copy:
    12          #src: /bin/sh
    13          #dest: /bin/sh.orig
    14    install:
    15      - apk:
    16          name: curl
    17          update_cache: yes
    18        tag: aloha
    19    setup:
    20      - command: ls -la /bin
```