### PR TITLE
dapp dimg run command: аргументы по умолчанию и опция '--stage STAGE'

### DIFF
--- a/config/en/net_status.yml
+++ b/config/en/net_status.yml
@@ -5,6 +5,7 @@ en:
       shell_command_failed: ">>> START STREAM\n%{stream}\n>>> END STREAM"
     dimg:
       dimg_not_built: "Dimg hasn't been built yet!"
+      dimg_stage_not_built: "Dimg stage `%{stage_name}` hasn't been built yet!"
       dimg_not_run: "Dimg run failed!"
     dappfile:
       incorrect: "Dappfile with `%{error}`:\n%{message}"

--- a/docs/pages/command/debugging.md
+++ b/docs/pages/command/debugging.md
@@ -13,11 +13,14 @@ dapp dimg list [options] [DIMG ...]
 ```
 
 ### dapp dimg run
-Запустить собранный dimg с докерными аргументами **DOCKER ARGS**.
+Запустить собранную стадию dimg-а с докерными аргументами **DOCKER ARGS**.
 
 ```
 dapp dimg run [options] [DIMG] [DOCKER ARGS]
 ```
+
+#### `--stage STAGE`
+Определить стадию сборки. По умолчанию используется последняя стадия.
 
 #### [DOCKER ARGS]
 Может содержать докерные опции и/или команду.

--- a/lib/dapp/dimg/cli/command/base.rb
+++ b/lib/dapp/dimg/cli/command/base.rb
@@ -1,6 +1,16 @@
 module Dapp::Dimg::CLI
   module Command
     class Base < ::Dapp::CLI::Command::Base
+      DIMG_STAGES = [
+        :from, :before_install, :before_install_artifact, :g_a_archive, :g_a_pre_install_patch, :install,
+        :g_a_post_install_patch, :after_install_artifact, :before_setup, :before_setup_artifact,
+        :g_a_pre_setup_patch, :setup, :g_a_post_setup_patch, :after_setup_artifact, :g_a_latest_patch, :docker_instructions
+      ].freeze
+
+      STAGE_PROC = proc do |stages|
+        proc { |val| val.to_sym.tap { |v| in_validate!(v, stages) } }
+      end
+
       option :build_dir,
              long: "--build-dir PATH",
              description: "Directory where build cache stored ($HOME/.dapp/builds/<dapp name> by default)."

--- a/lib/dapp/dimg/cli/command/dimg/build.rb
+++ b/lib/dapp/dimg/cli/command/dimg/build.rb
@@ -11,25 +11,16 @@ Usage:
 
 Options:
 BANNER
-        introspected_stages = [
-          :from, :before_install, :before_install_artifact, :g_a_archive, :g_a_pre_install_patch, :install,
-          :g_a_post_install_patch, :after_install_artifact, :before_setup, :before_setup_artifact,
-          :g_a_pre_setup_patch, :setup, :g_a_post_setup_patch, :after_setup_artifact, :g_a_latest_patch, :docker_instructions
-        ]
-        artifact_introspected_stages = [
+        artifact_stages = [
           :from, :before_install, :before_install_artifact, :g_a_archive, :g_a_pre_install_patch, :install,
           :g_a_post_install_patch, :after_install_artifact, :before_setup, :before_setup_artifact,
           :g_a_pre_setup_patch, :setup, :after_setup_artifact, :g_a_artifact_patch, :build_artifact
         ]
 
-        introspect_stage_proc = proc do |stages|
-          proc { |val| val.to_sym.tap { |v| in_validate!(v, stages) } }
-        end
-
-        introspect_before_proc = proc do |stages|
+        before_stage_proc = proc do |stages|
           proc do |val|
             val_sym = val.to_sym
-            introspect_stage_proc.call(stages[1..-1]).call(val_sym)
+            STAGE_PROC.call(stages[1..-1]).call(val_sym)
             stages[stages.index(val_sym) - 1]
           end
         end
@@ -58,24 +49,24 @@ BANNER
                default: false
 
         option :introspect_stage,
-               long: '--introspect-stage STAGE',
-               description: "Introspect one of the following stages (#{list_msg_format(introspected_stages)})",
-               proc: introspect_stage_proc.call(introspected_stages)
+               long:        '--introspect-stage STAGE',
+               description: "Introspect one of the following stages (#{list_msg_format(DIMG_STAGES)})",
+               proc:        STAGE_PROC.call(DIMG_STAGES)
 
         option :introspect_before,
-               long: '--introspect-before STAGE',
-               description: "Introspect stage before one of the following stages (#{list_msg_format(introspected_stages[1..-1])})",
-               proc: introspect_before_proc.call(introspected_stages)
+               long:        '--introspect-before STAGE',
+               description: "Introspect stage before one of the following stages (#{list_msg_format(DIMG_STAGES[1..-1])})",
+               proc:        before_stage_proc.call(DIMG_STAGES)
 
         option :introspect_artifact_stage,
-               long: '--introspect-artifact-stage STAGE',
-               description: "Introspect one of the following stages (#{list_msg_format(artifact_introspected_stages)})",
-               proc: introspect_stage_proc.call(artifact_introspected_stages)
+               long:        '--introspect-artifact-stage STAGE',
+               description: "Introspect one of the following stages (#{list_msg_format(artifact_stages)})",
+               proc:        STAGE_PROC.call(artifact_stages)
 
         option :introspect_artifact_before,
-               long: '--introspect-artifact-before STAGE',
-               description: "Introspect stage before one of the following stages (#{list_msg_format(artifact_introspected_stages[1..-1])})",
-               proc: introspect_before_proc.call(artifact_introspected_stages)
+               long:        '--introspect-artifact-before STAGE',
+               description: "Introspect stage before one of the following stages (#{list_msg_format(artifact_stages[1..-1])})",
+               proc:        before_stage_proc.call(artifact_stages)
 
         option :ssh_key,
                long: '--ssh-key SSH_KEY',

--- a/lib/dapp/dimg/cli/command/dimg/run.rb
+++ b/lib/dapp/dimg/cli/command/dimg/run.rb
@@ -12,6 +12,11 @@ Usage:
 
 Options:
 BANNER
+        option :stage,
+               long:        '--stage STAGE',
+               description: "Run one of the following stages (#{list_msg_format(DIMG_STAGES)})",
+               proc:        STAGE_PROC.call(DIMG_STAGES)
+
         option :ssh_key,
                long: '--ssh-key SSH_KEY',
                description: ['Enable only specified ssh keys ',
@@ -51,8 +56,16 @@ BANNER
           index = filtered_args.index('--') || filtered_args.count
           docker_options = index.nonzero? ? filtered_args.slice(0..index - 1) : []
           command = filtered_args.slice(index + 1..-1) || []
+
+          if docker_options.empty? && command.empty?
+            docker_options = %w(-ti --rm)
+            command = %w(/bin/bash)
+          end
+
+          stage_name = config.delete(:stage)
+
           run_dapp_command(nil, options: cli_options(dimgs_patterns: patterns), log_running_time: false) do |dapp|
-            dapp.run(docker_options, command)
+            dapp.run(stage_name, docker_options, command)
           end
         end
       end

--- a/lib/dapp/dimg/dapp/command/run.rb
+++ b/lib/dapp/dimg/dapp/command/run.rb
@@ -3,10 +3,11 @@ module Dapp
     module Dapp
       module Command
         module Run
-          def run(docker_options, command)
+          def run(stage_name, docker_options, command)
             one_dimg!
             setup_ssh_agent
-            dimg(config: build_configs.first, ignore_git_fetch: true, should_be_built: true).run(docker_options, command)
+            dimg(config: build_configs.first, ignore_git_fetch: true, should_be_built: stage_name.nil?)
+              .run_stage(stage_name, docker_options, command)
           end
         end
       end

--- a/lib/dapp/dimg/dimg.rb
+++ b/lib/dapp/dimg/dimg.rb
@@ -139,7 +139,13 @@ module Dapp
       end
 
       def run(docker_options, command)
-        cmd = "#{dapp.host_docker} run #{[docker_options, last_stage.image.built_id, command].flatten.compact.join(' ')}"
+        run_stage(nil, docker_options, command)
+      end
+
+      def run_stage(stage_name, docker_options, command)
+        stage_image = (stage_name.nil? ? last_stage : stage_by_name(stage_name)).image
+        raise Error::Dimg, code: :dimg_stage_not_built, data: { stage_name: stage_name } unless stage_image.built?
+        cmd = "#{dapp.host_docker} run #{[docker_options, stage_image.built_id, command].flatten.compact.join(' ')}"
         if dapp.dry_run?
           dapp.log(cmd)
         else

--- a/spec/unit/cli_spec.rb
+++ b/spec/unit/cli_spec.rb
@@ -53,10 +53,15 @@ describe Dapp::CLI do
     end
 
     def expect_parsed_options(cmd, options: {}, docker_options: [], docker_command: [])
+      if docker_options.empty? && docker_command.empty?
+        docker_options = %w(-ti --rm)
+        docker_command = %w(/bin/bash)
+      end
+
       expect { cli(*cmd.split) }.to_not raise_error
       expect(@instance.options).to include(options)
       expect(@instance.dimgs_patterns).to eq options[:dimgs_patterns] || ['*']
-      expect(@instance).to have_received(:run).with(docker_options, docker_command)
+      expect(@instance).to have_received(:run).with(nil, docker_options, docker_command)
     end
   end
 end

--- a/spec/unit/dapp_spec.rb
+++ b/spec/unit/dapp_spec.rb
@@ -37,7 +37,7 @@ describe Dapp::Dapp do
   end
 
   it 'run:command_unexpected_dimgs_number', :push do
-    expect_exception_code(:command_unexpected_dimgs_number) { stubbed_dapp.run([], []) }
+    expect_exception_code(:command_unexpected_dimgs_number) { stubbed_dapp.run(nil, [], []) }
   end
 
   it 'list' do


### PR DESCRIPTION
* если `DOCKER ARGS` не переданы, то используются значения по умолчанию и результирующая команда принимает следующий вид: `docker run -ti --rm <stage-image-id> /bin/bash`;
* команду можно вызвать для конкретной собранной стадии (опция `--stage STAGE), при этом сам dimg может быть собран частично.