### PR TITLE
(sentry) Capture more data for sentry

### DIFF
--- a/lib/dapp/dapp/sentry.rb
+++ b/lib/dapp/dapp/sentry.rb
@@ -4,12 +4,12 @@ module Dapp
       def sentry_message(msg, **kwargs)
         return if not ensure_sentry_configured
         kwargs[:level] ||= "info"
-        Raven.capture_message(msg, _sentry_params(**kwargs))
+        Raven.capture_message(msg, _make_sentry_params(**kwargs))
       end
 
       def sentry_exception(exception, **kwargs)
         return if not ensure_sentry_configured
-        Raven.capture_exception(exception, _sentry_params(**kwargs))
+        Raven.capture_exception(exception, _make_sentry_params(**kwargs))
       end
 
       def ensure_sentry_configured
@@ -30,7 +30,7 @@ module Dapp
         return true
       end
 
-      def _sentry_params(level: nil, tags: {}, extra: {}, user: {})
+      def _make_sentry_params(level: nil, tags: {}, extra: {}, user: {})
         {
           level: level,
           tags:  _sentry_tags_context.merge(tags),
@@ -40,15 +40,17 @@ module Dapp
       end
 
       def _sentry_extra_context
-        {
+        @_sentry_extra_context ||= {
           "pwd" => Dir.pwd,
           "dapp-dir" => self.work_dir,
           "build-dir" => self.build_dir,
           "options" => self.options,
-          "DAPP_FORCE_SAVE_CACHE" => ENV["DAPP_FORCE_SAVE_CACHE"],
-          "DAPP_BIN_DAPPFILE_YML" => ENV["DAPP_BIN_DAPPFILE_YML"],
-          "ANSIBLE_ARGS" => ENV["ANSIBLE_ARGS"],
-          "DAPP_CHEF_DEBUG" => ENV["DAPP_CHEF_DEBUG"],
+          "env-options" => {
+            "DAPP_FORCE_SAVE_CACHE" => ENV["DAPP_FORCE_SAVE_CACHE"],
+            "DAPP_BIN_DAPPFILE_YML" => ENV["DAPP_BIN_DAPPFILE_YML"],
+            "ANSIBLE_ARGS" => ENV["ANSIBLE_ARGS"],
+            "DAPP_CHEF_DEBUG" => ENV["DAPP_CHEF_DEBUG"],
+          },
         }.tap {|extra|
           if git_own_repo_exist?
             extra["git"] = {
@@ -59,12 +61,20 @@ module Dapp
               "latest_commit" => git_own_repo.latest_commit,
             }
           end
+
+          extra["ci-env"] = {"CI" => ENV["CI"]}
+          ENV.select {|k, v| k.start_with?("CI_")}.each do |k, v|
+            extra["ci-env"][k] = v
+          end
         }
       end
 
       def _sentry_tags_context
-        {
+        @_sentry_tags_context ||= {
           "dapp-name" => self.name,
+          "dapp-short-version" => ::Dapp::VERSION.split(".")[0..1].join("."),
+          "dapp-version" => ::Dapp::VERSION,
+          "dapp-build-cache-version" => ::Dapp::BUILD_CACHE_VERSION,
         }.tap {|tags|
           if git_own_repo_exist?
             tags["git-host"] = self.get_host_from_git_url(git_own_repo.remote_origin_url)
@@ -74,11 +84,17 @@ module Dapp
             tags["git-group"] = git_name.partition("/")[0]
             tags["git-name"] = git_name
           end
+
+          begin
+            ver = self.class.host_docker_minor_version
+            tags["docker-minor-version"] = ver.to_s
+          rescue ::Exception
+          end
         }
       end
 
       def _sentry_user_context
-        {}
+        @__sentry_user_context ||= {}
       end
     end # Sentry
   end # Dapp

--- a/lib/dapp/kube/dapp/command/deploy.rb
+++ b/lib/dapp/kube/dapp/command/deploy.rb
@@ -165,6 +165,7 @@ module Dapp
                     # Поэтому перехватываем и просто отображаем произошедшую
                     # ошибку для информации пользователю без завершения работы dapp.
                     $stderr.puts(::Dapp::Dapp.paint_string(::Dapp::Helper::NetStatus.message(e), :warning))
+                    sentry_exception(e, extra: {"job-spec" => job.spec})
                   end
 
                 end # Thread


### PR DESCRIPTION
* All CI-env variables extra data.
* Dapp version tags data.
* Docker version tags data.
* Additional capture for deploy jobs-watcher Default exceptions from parallel thread.
  * Because these exceptions will not pass through bin/dapp main exception capture point.
