### PR TITLE
sentry: add info message and tags

### DIFF
--- a/lib/dapp/cli/command/base.rb
+++ b/lib/dapp/cli/command/base.rb
@@ -59,6 +59,7 @@ module Dapp
         def run_dapp_command(run_method, options: {}, try_host_docker_login: false)
           dapp = ::Dapp::Dapp.new(options: options)
           ::Dapp::CLI.dapp_object = dapp
+          dapp.sentry_message("Manual usage: `#{options[:dapp_command]}` command") unless ENV['CI']
 
           log_dapp_running_time(dapp) do
             begin
@@ -73,6 +74,10 @@ module Dapp
               dapp.terminate
             end
           end
+        end
+
+        def run_method
+          class_to_lowercase
         end
 
         def log_dapp_running_time(dapp)
@@ -100,7 +105,7 @@ module Dapp
             self.class.print_error_with_help_and_die! self, "cannot use alias options --run-dir, --build-dir, --deploy-dir at the same time"
           end
 
-          config.merge(build_dir: dirs.compact.first, **kwargs)
+          config.merge(build_dir: dirs.compact.first, dapp_command: run_method, **kwargs)
         end
       end
     end

--- a/lib/dapp/dimg/cli/command/base.rb
+++ b/lib/dapp/dimg/cli/command/base.rb
@@ -19,10 +19,6 @@ module Dapp::Dimg::CLI
         self.class.parse_options(self, argv)
         run_dapp_command(run_method, options: cli_options(dimgs_patterns: cli_arguments))
       end
-
-      def run_method
-        class_to_lowercase
-      end
     end
   end
 end

--- a/lib/dapp/dimg/dimg.rb
+++ b/lib/dapp/dimg/dimg.rb
@@ -122,7 +122,7 @@ module Dapp
         @registry ||= dapp.dimg_registry
       end
 
-      def  build_export_image!(image_name, scheme_name:)
+      def build_export_image!(image_name, scheme_name:)
         Image::Dimg.image_by_name(name: image_name, from: last_stage.image, dapp: dapp).tap do |export_image|
           export_image.add_service_change_label(:'dapp-tag-scheme' => scheme_name)
           export_image.add_service_change_label(:'dapp-dimg' => true)


### PR DESCRIPTION
* manual usage info message if dapp isn't used by CI
* tags: error-code, dapp-command