### PR TITLE
`user not authorized` on dapp dimg cleanup repo

### DIFF
--- a/lib/dapp/dapp/sentry.rb
+++ b/lib/dapp/dapp/sentry.rb
@@ -35,12 +35,12 @@ module Dapp
       end
 
       def _make_sentry_params(level: nil, tags: {}, extra: {}, user: {})
-        {
+        Marshal.load(Marshal.dump({
           level: level,
           tags:  _sentry_tags_context.merge(tags),
           extra: _sentry_extra_context.merge(extra),
           user:  _sentry_user_context.merge(user),
-        }
+        }))
       end
 
       def _sentry_extra_context


### PR DESCRIPTION
After sentry_message call all password-related data stored in ruby hashes changes to `*` symbols.