### PR TITLE
dapp dimg cleanup repo: change limit policy logic

### DIFF
--- a/lib/dapp/dimg/dapp/command/common.rb
+++ b/lib/dapp/dimg/dapp/command/common.rb
@@ -48,7 +48,7 @@ module Dapp
                 .reject(&:empty?)
                 .each do |l|
                 id, name, created_at = l.split(';')
-                images << { id: id, name: name, created_at: Time.parse(created_at), **extra_fields }
+                images << { id: id, name: name, created_at: Time.parse(created_at).to_i, **extra_fields }
               end
             end
           end

--- a/lib/dapp/dimg/dapp/command/stages/cleanup_local.rb
+++ b/lib/dapp/dimg/dapp/command/stages/cleanup_local.rb
@@ -46,7 +46,7 @@ module Dapp
 
                   # Удаление только образов старше 2ч
                   dimgstages.delete_if do |dimgstage|
-                    Time.now - dimgstage[:created_at] < 2 * 60 * 60
+                    Time.now.to_i - dimgstage[:created_at] < 2 * 60 * 60
                   end unless ENV['DAPP_STAGES_CLEANUP_LOCAL_DISABLED_DATE_POLICY']
 
                   remove_project_images(dimgstages)

--- a/lib/dapp/dimg/dapp/command/stages/common.rb
+++ b/lib/dapp/dimg/dapp/command/stages/common.rb
@@ -9,6 +9,7 @@ module Dapp
             def repo_detailed_dimgs_images(registry)
               repo_dimgs_images(registry).each do |dimg|
                 image_history = registry.image_history(dimg[:tag], dimg[:dimg])
+                dimg[:created_at] = Time.parse(image_history['created']).to_i
                 dimg[:parent] = image_history['container_config']['Image']
                 dimg[:labels] = image_history['config']['Labels']
               end

--- a/lib/dapp/dimg/git_repo/base.rb
+++ b/lib/dapp/dimg/git_repo/base.rb
@@ -146,11 +146,6 @@ module Dapp
           raise Error::Rugged, code: :git_repository_reference_error, data: { name: name, message: e.message.downcase }
         end
 
-        def tag_at(name)
-          tag = git.tags.find { |t| t.name == name }
-          tag.target.time.to_i
-        end
-
         def tags
           git.tags.map(&:name)
         end
@@ -161,11 +156,7 @@ module Dapp
             .select { |b| b.start_with?('origin/') }
             .map { |b| b.reverse.chomp('origin/'.reverse).reverse }
         end
-
-        def commit_at(commit)
-          lookup_commit(commit).time.to_i
-        end
-
+        
         def find_commit_id_by_message(regex)
           walker.each do |commit|
             msg = commit.message.encode('UTF-8', invalid: :replace, undef: :replace)


### PR DESCRIPTION
* store 10 images per dimg sorted by creation date for `commit` && `tag` schemes

closes https://github.com/flant/dapp/issues/669