### PR TITLE
deploy commands: support ci environment variables in helm templates

### DIFF
--- a/lib/dapp/kube/helm/values.rb
+++ b/lib/dapp/kube/helm/values.rb
@@ -16,7 +16,8 @@ module Dapp
                 "name" => dapp.name,
                 "repo" => repo,
                 "docker_tag" => docker_tag,
-              }
+              },
+              "ci" => ENV.select { |k, _| k.start_with?("CI_") } ,
             }
           }
 


### PR DESCRIPTION
* each variable available by key like `.Values.global.ci.CI_<VARIABLE_NAME>`

closes #707