### PR TITLE
Update submodule logic: always use superproject’s recorded submodule SHA-1

### DIFF
--- a/dapp.gemspec
+++ b/dapp.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n', '~> 0.7'
   s.add_dependency 'paint', '~> 1.0', '>= 1.0.1'
   s.add_dependency 'inifile', '~> 3.0.0'
-  s.add_dependency 'rugged', '~> 0.24.0'
+  s.add_dependency 'rugged', '~> 0.27.0'
   s.add_dependency 'murmurhash3', '~> 0.1.6'
   s.add_dependency 'slugify', '~> 1.0', '>= 1.0.6'
   s.add_dependency 'progressbar', '~> 1.9.0'

--- a/lib/dapp/dimg/dimg/git_artifact.rb
+++ b/lib/dapp/dimg/dimg/git_artifact.rb
@@ -19,10 +19,7 @@ module Dapp
         def remote_git_artifacts
           @remote_git_artifact_list ||= [].tap do |artifacts|
             Array(config._git_artifact._remote).each do |ga_config|
-              repo = GitRepo::Remote.get_or_create(dapp, ga_config._name,
-                                                   url: ga_config._url,
-                                                   branch: ga_config._branch,
-                                                   ignore_git_fetch: ignore_git_fetch)
+              repo = GitRepo::Remote.get_or_create(dapp, ga_config._name, url: ga_config._url, ignore_git_fetch: ignore_git_fetch)
               artifacts.concat(generate_git_artifacts(repo, **ga_config._artifact_options)) unless repo.empty?
             end
           end

--- a/lib/dapp/dimg/dimg/git_artifact.rb
+++ b/lib/dapp/dimg/dimg/git_artifact.rb
@@ -27,7 +27,7 @@ module Dapp
 
         def generate_git_artifacts(repo, **git_artifact_options)
           [].tap do |artifacts|
-            artifacts << (artifact = ::Dapp::Dimg::GitArtifact.new(repo, self, **git_artifact_options))
+            artifacts << (artifact = ::Dapp::Dimg::GitArtifact.new(repo, self, ignore_signature_auto_calculation: ignore_signature_auto_calculation, **git_artifact_options))
             if ENV['DAPP_DISABLE_GIT_SUBMODULES']
               artifacts
             else

--- a/lib/dapp/dimg/git_artifact.rb
+++ b/lib/dapp/dimg/git_artifact.rb
@@ -101,6 +101,7 @@ module Dapp
               .to_h
           end
           options[:branch]              = embedded_params[:branch]
+          options[:commit]              = embedded_params[:commit]
           options[:owner]               = owner
           options[:group]               = group
         end

--- a/lib/dapp/dimg/git_artifact.rb
+++ b/lib/dapp/dimg/git_artifact.rb
@@ -70,10 +70,7 @@ module Dapp
         embedded_rel_path = embedded_params[:path]
         embedded_repo     = begin
           if embedded_params[:type] == :remote
-            GitRepo::Remote.get_or_create(repo.dapp, embedded_rel_path,
-                                          url: embedded_params[:url],
-                                          branch: embedded_params[:branch],
-                                          ignore_git_fetch: dimg.ignore_git_fetch )
+            GitRepo::Remote.get_or_create(repo.dapp, embedded_rel_path, url: embedded_params[:url], ignore_git_fetch: dimg.ignore_git_fetch)
           elsif embedded_params[:type] == :local
             embedded_path = File.join(repo.workdir_path, embedded_params[:path])
             GitRepo::Local.new(repo.dapp, embedded_rel_path, embedded_path)

--- a/spec/integration/submodule_spec.rb
+++ b/spec/integration/submodule_spec.rb
@@ -11,7 +11,6 @@ describe Dapp::Dimg::Dimg do
       https: 'https://github.com/flant/dapp-submodule-spec-project-https.git',
       relative_path: 'https://github.com/flant/dapp-submodule-spec-project-relative-path.git',
       nested: 'https://github.com/flant/dapp-submodule-spec-project-nested.git',
-      branches: 'https://github.com/flant/dapp-submodule-spec-project-branches.git'
     }
   end
 
@@ -135,9 +134,5 @@ EOF
     project_https_md5sum = calculate_md5sum(project_https_path)
 
     clone_project_and_expect_submodule(projects_origins[:nested], project_https_md5sum)
-  end
-
-  it 'branches', test_construct: true do
-    clone_project_and_expect_submodule(projects_origins[:branches], project_test_md5sum(:feature))
   end
 end

--- a/spec/spec_helper/dimg.rb
+++ b/spec/spec_helper/dimg.rb
@@ -21,7 +21,7 @@ module SpecHelper
             openstruct_config
           end
         end
-        @dapp = nil
+        dapp_renew
         dapp.dimg(**options)
       end
     end
@@ -46,6 +46,12 @@ module SpecHelper
           yield dapp if block_given?
         end
       end
+    end
+
+    def dapp_renew
+      return if dapp.nil?
+      dapp.terminate
+      @dapp = nil
     end
 
     def project_path
@@ -146,6 +152,5 @@ module SpecHelper
         allow(instance).to receive(:_terminate_dimg_on_terminate)
       end
     end
-
   end
 end

--- a/spec/unit/git_artifact_spec.rb
+++ b/spec/unit/git_artifact_spec.rb
@@ -524,11 +524,12 @@ describe Dapp::Dimg::GitArtifact do
 
     [
       ['**/*.rb', %w(**/*.rb *.rb)],
-      ['path/subpath', ['**']],
+      ['path/*', %w(**)],
+      ['path/subpath', %w(**)],
       ['path/subpath/**/*.exe', %w(**/*.exe)],
-      ['path/*th', ['**']],
-      ['path/subpath2', []],
-      ['path/subpath2/**/*.html', []]
+      ['path/*th', %w(**)],
+      ['path/subpath2', %w()],
+      ['path/subpath2/**/*.html', %w()]
     ].each do |path, expected|
       it "#{path} => #{expected}" do
         expect(git_artifact_embedded_inherit_path(path, 'path/subpath')).to eq expected

--- a/spec/unit/git_repo_spec.rb
+++ b/spec/unit/git_repo_spec.rb
@@ -24,7 +24,7 @@ describe Dapp::Dimg::GitRepo do
     @remote = Dapp::Dimg::GitRepo::Remote.new(dapp, 'local_remote', url: 'remote/.git')
 
     expect(File.exist?(@remote.path)).to be_truthy
-    expect(@remote.path.to_s[/.*\/([^\/]*\/[^\/]*\/[^\/]*)/, 1]).to eq "remote_git_repo/#{Dapp::Dimg::GitRepo::Remote::CACHE_VERSION}/local_remote"
+    expect(@remote.path.to_s[/.*\/([^\/]*\/[^\/]*\/[^\/]*)/, 1]).to eq "remote_git_repo/#{Dapp::Dimg::GitRepo::Remote::CACHE_VERSION}/#{dapp.consistent_uniq_slugify("local_remote")}"
   end
 
   it 'Remote#init', test_construct: true do


### PR DESCRIPTION
* dapp.gemspec: up rugged
* git remote: fetch all instead of specific branch
* Update submodule logic: always use superproject’s recorded submodule SHA-1
* dapp dimg build: up logging

closes https://github.com/flant/dapp/issues/671