### PR TITLE
[kube] Kubernetes tcp timeouts option and auto-retry requests

### DIFF
--- a/lib/dapp/dimg/cli/command/dimg/cleanup_repo.rb
+++ b/lib/dapp/dimg/cli/command/dimg/cleanup_repo.rb
@@ -15,6 +15,11 @@ BANNER
                description: 'Redefine resource locking timeout (in seconds)',
                proc: ->(v) { v.to_i }
 
+        option :kubernetes_timeout,
+               long: '--kubernetes-timeout TIMEOUT',
+               description: 'Kubernetes api-server tcp connection, read and write timeout (in seconds)',
+               proc: ->(v) { v.to_i }
+
         option :with_stages,
                long: '--with-stages',
                boolean: true

--- a/lib/dapp/dimg/dapp/command/cleanup_repo.rb
+++ b/lib/dapp/dimg/dapp/command/cleanup_repo.rb
@@ -137,7 +137,12 @@ module Dapp
 
             config.context_names.
               map {|context_name|
-                client = ::Dapp::Kube::Kubernetes::Client.new(config, context_name, "default")
+                client = ::Dapp::Kube::Kubernetes::Client.new(
+                  config,
+                  context_name,
+                  "default",
+                  timeout: options[:kubernetes_timeout],
+                )
                 search_deployed_docker_images_from_kube(client)
               }.flatten.sort.uniq
           end

--- a/lib/dapp/kube/cli/command/kube/deploy.rb
+++ b/lib/dapp/kube/cli/command/kube/deploy.rb
@@ -50,6 +50,11 @@ BANNER
              description: 'Default timeout to wait for resources to become ready, 300 seconds by default.',
              proc: proc {|v| Integer(v)}
 
+      option :kubernetes_timeout,
+             long: '--kubernetes-timeout TIMEOUT',
+             description: 'Kubernetes api-server tcp connection, read and write timeout (in seconds)',
+             proc: ->(v) { v.to_i }
+
       option :registry_username,
              long: '--registry-username USERNAME'
 

--- a/lib/dapp/kube/cli/command/kube/dismiss.rb
+++ b/lib/dapp/kube/cli/command/kube/dismiss.rb
@@ -20,6 +20,12 @@ BANNER
       option :with_namespace,
              long: '--with-namespace',
              default: false
+
+      option :kubernetes_timeout,
+             long: '--kubernetes-timeout TIMEOUT',
+             description: 'Kubernetes api-server tcp connection, read and write timeout (in seconds)',
+             proc: ->(v) { v.to_i }
+
     end
   end
 end

--- a/lib/dapp/kube/cli/command/kube/minikube_setup.rb
+++ b/lib/dapp/kube/cli/command/kube/minikube_setup.rb
@@ -8,6 +8,12 @@ Usage:
 
 Options:
 BANNER
+
+      option :kubernetes_timeout,
+        long: '--kubernetes-timeout TIMEOUT',
+        description: 'Kubernetes api-server tcp connection, read and write timeout (in seconds)',
+        proc: ->(v) { v.to_i }
+
     end
   end
 end

--- a/lib/dapp/kube/dapp/command/common.rb
+++ b/lib/dapp/kube/dapp/command/common.rb
@@ -366,6 +366,7 @@ image: {{ tuple $name $context | include "_dimg2" }}
               kubernetes_config,
               kube_context,
               kube_namespace,
+              timeout: options[:kubernetes_timeout],
             )
           end
         end

--- a/lib/dapp/kube/dapp/command/minikube_setup.rb
+++ b/lib/dapp/kube/dapp/command/minikube_setup.rb
@@ -254,7 +254,8 @@ module Dapp
             @_minikube_kubernetes ||= Kubernetes::Client.new(
               kubernetes_config,
               kubernetes_config.current_context_name,
-              'kube-system'
+              'kube-system',
+              timeout: options[:kubernetes_timeout],
             )
           end
 


### PR DESCRIPTION
* Set connection, read and write timeouts to the value specified in option `--kubernetes-timeout`.
* Auto retry all GET requests to kubernetes api-server. 6 retry attempts with 5 seconds pause in between.