### PR TITLE
[kube] dapp/watch=false to disable Deployment watch during deploy

### DIFF
--- a/lib/dapp/kube/dapp/command/deploy.rb
+++ b/lib/dapp/kube/dapp/command/deploy.rb
@@ -217,7 +217,11 @@ module Dapp
               unless dry_run?
                 begin
                   ::Timeout::timeout(self.options[:timeout] || 300) do
-                    deployment_managers.each {|deployment_manager| deployment_manager.watch_till_ready!}
+                    deployment_managers.each {|deployment_manager|
+                      if deployment_manager.should_watch?
+                        deployment_manager.watch_till_ready!
+                      end
+                    }
                   end
                 rescue ::Timeout::Error
                   raise ::Dapp::Error::Command, code: :kube_deploy_timeout

--- a/lib/dapp/kube/kubernetes/manager/deployment.rb
+++ b/lib/dapp/kube/kubernetes/manager/deployment.rb
@@ -30,6 +30,14 @@ module Dapp
           @deployed_at = Time.now
         end
 
+        def should_watch?
+          d = Kubernetes::Client::Resource::Deployment.new(dapp.kubernetes.deployment(name))
+
+          ["dapp/watch", "dapp/watch-logs"].all? do |anno|
+            d.annotations[anno] != "false"
+          end
+        end
+
         def watch_till_ready!
           dapp.log_process("Watch deployment '#{name}' till ready") do
             known_events_by_pod = {}


### PR DESCRIPTION
By default dapp will watch all deployments rolling oout status after calling helm.
If Deployment has annotation dapp/watch=false or dapp/watch-logs=false,
then dapp will not watch this deployment.