### PR TITLE
[fix] Error: failed parsing --set data: ... has no value

### DIFF
--- a/lib/dapp/kube/helm/values.rb
+++ b/lib/dapp/kube/helm/values.rb
@@ -17,7 +17,7 @@ module Dapp
                 "repo" => repo,
                 "docker_tag" => docker_tag,
               },
-              "ci" => ENV.select { |k, _| k.start_with?('CI_') },
+              "ci" => ENV.select { |k, _| k.start_with?('CI_') && k != "CI_ENVIRONMENT_URL" },
             }
           }
 


### PR DESCRIPTION
Exclude .Values.global.ci.CI_ENVIRONMENT_URL variable.
This variable can have broken unexpanded value.