### PR TITLE
GCE kubernetes return minor version as 10+

### DIFF
--- a/lib/dapp/kube/kubernetes/client.rb
+++ b/lib/dapp/kube/kubernetes/client.rb
@@ -163,8 +163,8 @@ module Dapp
           version_obj = request!(:get, "/version", **query_parameters)
           @cluster_version ||= begin
             major = version_obj['major']
-            minor = version_obj['minor']
-            k8s_version = "#{version_obj['major']}.#{version_obj['minor']}"
+            minor = version_obj['minor'].gsub(/\+$/,'')
+            k8s_version = "#{major}.#{minor}"
             if K8S_API_ENDPOINTS.has_key?(k8s_version)
               k8s_version
             else


### PR DESCRIPTION
GCE Kubernetes somehow send a minor version with +. Example:

```
Server Version: version.Info{Major:"1", Minor:"10+", GitVersion:"v1.10.4-gke.2", GitCommit:"eb2e43842aaa21d6f0bb65d6adf5a84bbdc62eaf", GitTreeState:"clean", BuildDate:"2018-06-15T21:48:39Z", GoVersion:"go1.9.3b4", Compiler:"gc", Platform:"linux/amd64"}
```