### PR TITLE
[deploy] Fix 404 NotFound `.../deployments/RELEASE-NAME-...`

### DIFF
--- a/lib/dapp/kube/helm/release.rb
+++ b/lib/dapp/kube/helm/release.rb
@@ -122,6 +122,7 @@ module Dapp
             helm_additional_values_options,
             helm_set_options(without_registry: true),
             ("--namespace #{namespace}" if namespace),
+            "--name #{name}",
           ].compact.join(" ")
 
           cmd.stdout


### PR DESCRIPTION
The problem arises when using `.Release.Name`
helm value in subchart for example.

Pass real release name to `helm template` invocation,
which used to render yaml-specs of resources being deployed
for internal dapp usage.