### PR TITLE
[cleanup] Fix `uninitialized constant Dapp::Dimg::DockerRegistry::Error::NotFound`

### DIFF
--- a/lib/dapp/dimg/dapp/command/stages/common.rb
+++ b/lib/dapp/dimg/dapp/command/stages/common.rb
@@ -14,7 +14,7 @@ module Dapp
                   dimg[:parent] = image_history['container_config']['Image']
                   dimg[:labels] = image_history['config']['Labels'] || {}
                   dimg[:labels]['dapp'] == name
-                rescue DockerRegistry::Error::ManifestInvalid => err
+                rescue ::Dapp::Dimg::DockerRegistry::Error::ManifestInvalid => err
                   log_warning "WARNING: Ignore dimg `#{dimg[:dimg]}` tag `#{dimg[:tag]}`: got manifest-invalid-error from docker registry: #{err.message}"
                   false
                 end
@@ -52,7 +52,7 @@ module Dapp
                 end
 
                 return { dimg: dimg_name, tag: tag, id: id }
-              rescue DockerRegistry::Error::NotFound => err
+              rescue ::Dapp::Dimg::DockerRegistry::Error::NotFound => err
                 log_warning "WARNING: Ignore dimg `#{dimg_name}` tag `#{tag}`: got not-found-error from docker registry on get-image-manifest request: #{err.message}"
                 return nil
               end
@@ -63,7 +63,7 @@ module Dapp
               unless dry_run?
                 begin
                   registry.image_delete(repo_image[:tag], repo_image[:dimg])
-                rescue DockerRegistry::Error::NotFound => err
+                rescue ::Dapp::Dimg::DockerRegistry::Error::NotFound => err
                   log_warning "WARNING: Ignore dimg `#{repo_image[:dimg]}` tag `#{repo_image[:tag]}`: got not-found-error from docker registry on image-delete request: #{err.message}"
                 end
               end

--- a/lib/dapp/dimg/docker_registry/base.rb
+++ b/lib/dapp/dimg/docker_registry/base.rb
@@ -70,9 +70,9 @@ module Dapp
           url = api_url(*uri)
           request(url, **default_api_options.merge(options))
         rescue Excon::Error::MethodNotAllowed
-          raise DockerRegistry::Error::Base, code: :method_not_allowed, data: { url: url, registry: api_url, method: options[:method] }
+          raise ::Dapp::Dimg::DockerRegistry::Error::Base, code: :method_not_allowed, data: { url: url, registry: api_url, method: options[:method] }
         rescue Excon::Error::NotFound
-          raise DockerRegistry::Error::ImageNotFound.new(url, api_url)
+          raise ::Dapp::Dimg::DockerRegistry::Error::ImageNotFound.new(url, api_url)
         rescue Excon::Error::Unauthorized
           user_not_authorized!
         rescue Excon::Error => err
@@ -81,13 +81,13 @@ module Dapp
             if response_data
               (response_data["errors"] || []).each do |err_data|
                 if err_data["code"] == "MANIFEST_INVALID"
-                  raise DockerRegistry::Error::ManifestInvalid.new(url, api_url, "#{err.response.status_line.strip}: #{err.response.reason_phrase.strip}: #{err.response.body.strip}")
+                  raise ::Dapp::Dimg::DockerRegistry::Error::ManifestInvalid.new(url, api_url, "#{err.response.status_line.strip}: #{err.response.reason_phrase.strip}: #{err.response.body.strip}")
                 end
               end
             end
           end
 
-          raise(DockerRegistry::Error::Base,
+          raise(::Dapp::Dimg::DockerRegistry::Error::Base,
             code: :unknown_error,
             data: { url: url,
                     registry: api_url,
@@ -104,7 +104,7 @@ module Dapp
         end
 
         def user_not_authorized!
-          raise DockerRegistry::Error::Base, code: :user_not_authorized, data: { registry: api_url }
+          raise ::Dapp::Dimg::DockerRegistry::Error::Base, code: :user_not_authorized, data: { registry: api_url }
         end
       end
     end # DockerRegistry

--- a/lib/dapp/dimg/docker_registry/base/authorization.rb
+++ b/lib/dapp/dimg/docker_registry/base/authorization.rb
@@ -9,7 +9,7 @@ module Dapp
                 when /Bearer/ then { headers: { Authorization: "Bearer #{authorization_token(authenticate_header)}" } }
                 when /Basic/ then { headers: { Authorization: "Basic #{authorization_auth}" } }
                 when nil then {}
-                else raise DockerRegistry::Error::Base, code: :authenticate_type_not_supported, data: { registry: api_url }
+                else raise ::Dapp::Dimg::DockerRegistry::Error::Base, code: :authenticate_type_not_supported, data: { registry: api_url }
               end
             end
           end
@@ -19,7 +19,7 @@ module Dapp
             realm = options.delete(:realm)
             begin
               response = raw_request(realm, headers: { Authorization: "Basic #{authorization_auth}" }, query: options, expects: [200])
-            rescue DockerRegistry::Error::Base
+            rescue ::Dapp::Dimg::DockerRegistry::Error::Base
               raise unless (response = raw_request(realm, query: options)).status == 200
             end
             JSON.load(response.body)['token']

--- a/lib/dapp/dimg/docker_registry/dimg.rb
+++ b/lib/dapp/dimg/docker_registry/dimg.rb
@@ -16,7 +16,7 @@ module Dapp
 
         def tags
           super
-        rescue DockerRegistry::Error::Base => e
+        rescue ::Dapp::Dimg::DockerRegistry::Error::Base => e
           raise unless e.net_status[:code] == :page_not_found
           []
         end


### PR DESCRIPTION
Use absolute constants paths in all DockerRegistry::Error related `raise` and `rescue`.