### PR TITLE
(way2go) git artifact: up latest commit logic

### DIFF
--- a/pkg/git_artifact/git_artifact.go
+++ b/pkg/git_artifact/git_artifact.go
@@ -32,6 +32,14 @@ func (ga *GitArtifact) GitRepo() (git_repo.GitRepo, error) {
 	return nil, fmt.Errorf("GitRepo not initialized")
 }
 
+func (ga *GitArtifact) IsLocal() bool {
+	if ga.LocalGitRepo != nil {
+		return true
+	} else {
+		return false
+	}
+}
+
 func (ga *GitArtifact) LatestCommit() (string, error) {
 	gitRepo, err := ga.GitRepo()
 	if err != nil {
@@ -51,5 +59,13 @@ func (ga *GitArtifact) LatestCommit() (string, error) {
 		return gitRepo.LatestBranchCommit(ga.Branch)
 	}
 
-	return gitRepo.HeadCommit()
+	if ga.IsLocal() {
+		return gitRepo.HeadCommit()
+	} else {
+		branchName, err := gitRepo.HeadBranchName()
+		if err != nil {
+			return "", err
+		}
+		return gitRepo.LatestBranchCommit(branchName)
+	}
 }

--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -3,6 +3,8 @@ package git_repo
 import (
 	"fmt"
 	"gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"strings"
 )
 
 type Base struct {
@@ -10,14 +12,7 @@ type Base struct {
 }
 
 func (repo *Base) getHeadCommitForRepo(repoPath string) (string, error) {
-	var err error
-
-	repository, err := git.PlainOpen(repoPath)
-	if err != nil {
-		return "", fmt.Errorf("cannot open repo: %s", err)
-	}
-
-	ref, err := repository.Head()
+	ref, err := repo.getReferenceForRepo(repoPath)
 	if err != nil {
 		return "", fmt.Errorf("cannot get repo head: %s", err)
 	}
@@ -25,11 +20,40 @@ func (repo *Base) getHeadCommitForRepo(repoPath string) (string, error) {
 	return fmt.Sprintf("%s", ref.Hash()), nil
 }
 
+func (repo *Base) getHeadBranchNameForRepo(repoPath string) (string, error) {
+	ref, err := repo.getReferenceForRepo(repoPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot get repo head: %s", err)
+	}
+
+	if ref.Name().IsBranch() {
+		branchRef := ref.Name()
+		return strings.Split(string(branchRef), "refs/heads/")[1], nil
+	} else {
+		return "", fmt.Errorf("cannot get branch name: HEAD refers to a specific revision that is not associated with a branch name")
+	}
+}
+
+func (repo *Base) getReferenceForRepo(repoPath string) (*plumbing.Reference, error) {
+	var err error
+
+	repository, err := git.PlainOpen(repoPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open repo: %s", err)
+	}
+
+	return repository.Head()
+}
+
 func (repo *Base) String() string {
 	return repo.Name
 }
 
 func (repo *Base) HeadCommit() (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
+func (repo *Base) HeadBranchName() (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -3,6 +3,7 @@ package git_repo
 type GitRepo interface {
 	String() string
 	HeadCommit() (string, error)
+	HeadBranchName() (string, error)
 	LatestBranchCommit(branch string) (string, error)
 	LatestTagCommit(tag string) (string, error)
 }

--- a/pkg/git_repo/remote.go
+++ b/pkg/git_repo/remote.go
@@ -156,6 +156,10 @@ func (repo *Remote) HeadCommit() (string, error) {
 	return commit, err
 }
 
+func (repo *Remote) HeadBranchName() (string, error) {
+	return repo.getHeadBranchNameForRepo(repo.ClonePath)
+}
+
 func (repo *Remote) findReference(rawRepo *git.Repository, reference string) (string, error) {
 	refs, err := rawRepo.References()
 	if err != nil {


### PR DESCRIPTION
* remote git artifact uses latest origin/branch commit if branch/tag/commit isn't specified