### PR TITLE
Fix `fatal: corrupt patch` build error

### DIFF
--- a/pkg/git_repo/archive.go
+++ b/pkg/git_repo/archive.go
@@ -11,10 +11,10 @@ import (
 	"runtime/pprof"
 	"time"
 
+	"github.com/flant/go-git/plumbing/filemode"
+	"github.com/flant/go-git/plumbing/object"
+	"github.com/flant/go-git/storage"
 	uuid "github.com/satori/go.uuid"
-	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
-	"gopkg.in/src-d/go-git.v4/plumbing/object"
-	"gopkg.in/src-d/go-git.v4/storage"
 )
 
 type Archive struct {

--- a/pkg/git_repo/base.go
+++ b/pkg/git_repo/base.go
@@ -5,10 +5,10 @@ import (
 	"io"
 	"strings"
 
-	"gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/object"
-	"gopkg.in/src-d/go-git.v4/storage"
+	git "github.com/flant/go-git"
+	"github.com/flant/go-git/plumbing"
+	"github.com/flant/go-git/plumbing/object"
+	"github.com/flant/go-git/storage"
 )
 
 type Base struct {

--- a/pkg/git_repo/patch.go
+++ b/pkg/git_repo/patch.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"io"
 
-	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/filemode"
-	fdiff "gopkg.in/src-d/go-git.v4/plumbing/format/diff"
-	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"github.com/flant/go-git/plumbing"
+	"github.com/flant/go-git/plumbing/filemode"
+	fdiff "github.com/flant/go-git/plumbing/format/diff"
+	"github.com/flant/go-git/plumbing/object"
 )
 
 type RelativeFilteredPatch struct {

--- a/pkg/git_repo/remote.go
+++ b/pkg/git_repo/remote.go
@@ -8,11 +8,11 @@ import (
 	"time"
 
 	"github.com/flant/dapp/pkg/lock"
+	git "github.com/flant/go-git"
+	"github.com/flant/go-git/plumbing"
+	"github.com/flant/go-git/plumbing/storer"
 	"gopkg.in/ini.v1"
 	"gopkg.in/satori/go.uuid.v1"
-	"gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/plumbing"
-	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 )
 
 type Remote struct {


### PR DESCRIPTION
Switched to github.com/flant/go-git fork with bugfix in git library.