### PR TITLE
(go-deeper) Fix `error parsing diff line: unexpected diff line: "similarity index ..."`

### DIFF
--- a/pkg/git/diff.go
+++ b/pkg/git/diff.go
@@ -32,7 +32,7 @@ func Diff(out io.Writer, repoPath string, opts DiffOptions) error {
 	cmd := exec.Command(
 		"git", "-C", repoPath,
 		"diff", opts.FromCommit, opts.ToCommit,
-		"--binary", submoduleOpt,
+		"--binary", "--no-renames", submoduleOpt,
 	)
 
 	stdoutPipe, err := cmd.StdoutPipe()


### PR DESCRIPTION
Disable renames in git diff patches.
Rename-diffs are not possible with include-paths/exclude-paths and base-path params of dapp git-artifacts (the same applies for copy-diffs).