### PR TITLE
(go-deeper) Fix `git apply: bad git-diff - inconsistent old filename`

### DIFF
--- a/pkg/true_git/diff_parser.go
+++ b/pkg/true_git/diff_parser.go
@@ -161,6 +161,12 @@ func (p *diffParser) handleDiffLine(line string) error {
 		if strings.HasPrefix(line, "Binary files") {
 			return p.handleShortBinaryHeader(line)
 		}
+		if strings.HasPrefix(line, "diff --git ") {
+			return p.handleDiffBegin(line)
+		}
+		if strings.HasPrefix(line, "Submodule ") {
+			return p.handleSubmoduleLine(line)
+		}
 		return p.writeOutLine(line)
 
 	case deleteFileDiff:
@@ -172,6 +178,12 @@ func (p *diffParser) handleDiffLine(line string) error {
 		}
 		if strings.HasPrefix(line, "Binary files") {
 			return p.handleShortBinaryHeader(line)
+		}
+		if strings.HasPrefix(line, "diff --git ") {
+			return p.handleDiffBegin(line)
+		}
+		if strings.HasPrefix(line, "Submodule ") {
+			return p.handleSubmoduleLine(line)
 		}
 		return p.writeOutLine(line)
 


### PR DESCRIPTION
Bad patch for empty file delete or create.