### PR TITLE
(go-deeper) Fix GitArtifact include/exclude paths bugs

### DIFF
--- a/lib/dapp/dapp.rb
+++ b/lib/dapp/dapp.rb
@@ -143,15 +143,6 @@ module Dapp
       make_path(build_dir, *path)
     end
 
-    def local_git_artifact_exclude_paths(&blk)
-      super do |exclude_paths|
-        build_path_relpath = Pathname.new(build_path).subpath_of(File.dirname(git_own_repo.path))
-        exclude_paths << build_path_relpath.to_s if build_path_relpath
-
-        yield exclude_paths if block_given?
-      end
-    end
-
     def stage_cache
       "dimgstage-#{name}"
     end

--- a/lib/dapp/dapp/git_artifact.rb
+++ b/lib/dapp/dapp/git_artifact.rb
@@ -1,12 +1,6 @@
 module Dapp
   class Dapp
     module GitArtifact
-      def local_git_artifact_exclude_paths(&blk)
-        @local_git_artifact_exclude_paths ||= [].tap do |exclude_paths|
-          yield exclude_paths if block_given?
-        end
-      end
-
       def dimgstage_g_a_commit_label(paramshash)
         "dapp-git-#{paramshash}-commit"
       end

--- a/lib/dapp/dimg/git_artifact.rb
+++ b/lib/dapp/dimg/git_artifact.rb
@@ -32,27 +32,9 @@ module Dapp
         @owner = owner
         @group = group
         @as = as
-
         @stages_dependencies = stages_dependencies
-
-
-        @all_include_paths = base_paths(@include_paths, true)
-        @all_exclude_paths = repo.exclude_paths + base_paths(@exclude_paths, true)
       end
       # rubocop:enable Metrics/ParameterLists
-
-      def base_paths(paths, with_cwd = false)
-        [paths].flatten.compact.map do |path|
-          if with_cwd && !cwd.empty?
-            File.join(cwd, path)
-          else
-            path
-          end
-            .chomp('/')
-            .reverse.chomp('/')
-            .reverse
-        end
-      end
 
       def apply_archive_command(stage)
         res = repo.dapp.ruby2go_git_artifact(
@@ -144,8 +126,8 @@ module Dapp
           "RepoPath" => File.join("/", @cwd.to_s),
           "Owner" => @owner.to_s,
           "Group" => @group.to_s,
-          "IncludePaths" => @all_include_paths,
-          "ExcludePaths" => @all_exclude_paths,
+          "IncludePaths" => @include_paths,
+          "ExcludePaths" => @exclude_paths,
           "StagesDependencies" => @stages_dependencies.map {|k, v| [_stages_map[k], Array(v).map(&:to_s)]}.to_h,
           "PatchesDir" => dimg.tmp_path('patches'),
           "ContainerPatchesDir" => dimg.container_tmp_path('patches'),

--- a/lib/dapp/dimg/git_repo/own.rb
+++ b/lib/dapp/dimg/git_repo/own.rb
@@ -5,10 +5,6 @@ module Dapp
         def initialize(dapp)
           super(dapp, 'own', dapp.path.to_s)
         end
-
-        def exclude_paths
-          dapp.local_git_artifact_exclude_paths
-        end
       end
     end
   end

--- a/pkg/build/git_artifact.go
+++ b/pkg/build/git_artifact.go
@@ -299,7 +299,11 @@ func (ga *GitArtifact) StageDependenciesChecksum(stageName string) (string, erro
 		return "", fmt.Errorf("unable to get latest commit: %s", err)
 	}
 
-	opts := git_repo.ChecksumOptions{Paths: depsPaths, Commit: commit}
+	opts := git_repo.ChecksumOptions{
+		FilterOptions: ga.getRepoFilterOptions(),
+		Paths:         depsPaths,
+		Commit:        commit,
+	}
 
 	checksum, err := ga.GitRepo().Checksum(opts)
 	if err != nil {

--- a/pkg/git_repo/git_repo.go
+++ b/pkg/git_repo/git_repo.go
@@ -14,6 +14,7 @@ type ArchiveOptions struct {
 }
 
 type ChecksumOptions struct {
+	FilterOptions
 	Paths  []string
 	Commit string
 }


### PR DESCRIPTION
* Include/exclude paths does not work when cwd has been specified.
* Include/exclude paths does not affect stageDependencies checksum.

closes #997