### PR TITLE
[kubedog] Use kubedog to watch job/deploy

### DIFF
--- a/cmd/deploy-watcher/main.go
+++ b/cmd/deploy-watcher/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/flant/dapp/pkg/lock"
+	"github.com/flant/dapp/pkg/ruby2go"
+
+	"github.com/flant/kubedog/pkg/kubedog"
+)
+
+func main() {
+	var err error
+
+	err = lock.Init()
+	if err != nil {
+		panic(err)
+	}
+
+	ruby2go.RunCli("deploy-watcher", func(args map[string]interface{}) (interface{}, error) {
+		namespace := args["namespace"].(string)
+		if namespace == "" {
+			return nil, fmt.Errorf("namespace argument required!")
+		}
+
+		resourceName := args["resourceName"].(string)
+		if resourceName == "" {
+			return nil, fmt.Errorf("resourceName argument required!")
+		}
+
+		switch action := args["action"]; action {
+		case "watch job":
+			err := kubedog.WatchJobTillDone(resourceName, namespace)
+			if err != nil {
+				return nil, fmt.Errorf("error watching job `%s` in namespace `%s`: %s", resourceName, namespace, err)
+			}
+		case "watch deployment":
+			err := kubedog.WatchDeploymentTillReady(resourceName, namespace)
+			if err != nil {
+				return nil, fmt.Errorf("error watching deployment `%s` in namespace `%s`: %s", resourceName, namespace, err)
+			}
+		default:
+			return nil, fmt.Errorf("unknown action \"%s\"", action)
+		}
+
+		return nil, nil
+	})
+}

--- a/go-build.sh
+++ b/go-build.sh
@@ -11,3 +11,4 @@ go install github.com/flant/dapp/cmd/dappdeps
 go install github.com/flant/dapp/cmd/docker_registry
 go install github.com/flant/dapp/cmd/cleanup
 go install github.com/flant/dapp/cmd/slug
+go install github.com/flant/dapp/cmd/deploy-watcher

--- a/go-env
+++ b/go-env
@@ -7,3 +7,4 @@ export DAPP_BIN_DAPPDEPS=$GOPATH/bin/dappdeps
 export DAPP_BIN_DOCKER_REGISTRY=$GOPATH/bin/docker_registry
 export DAPP_BIN_CLEANUP=$GOPATH/bin/cleanup
 export DAPP_BIN_SLUG=$GOPATH/bin/slug
+export DAPP_BIN_DEPLOY_WATCHER=$GOPATH/bin/deploy-watcher

--- a/lib/dapp/dapp/ruby2go.rb
+++ b/lib/dapp/dapp/ruby2go.rb
@@ -33,6 +33,10 @@ module Dapp
         _ruby2go("slug", args_hash)
       end
 
+      def ruby2go_deploy_watcher(args_hash)
+        _ruby2go("deploy-watcher", args_hash)
+      end
+
       def ruby2go_init
         @_call_after_before_terminate << proc {
           FileUtils.rmtree(@_ruby2go_tmp_dir) if @_ruby2go_tmp_dir

--- a/lib/dapp/kube/dapp/command/deploy.rb
+++ b/lib/dapp/kube/dapp/command/deploy.rb
@@ -157,7 +157,11 @@ module Dapp
                   begin
                     watch_hooks.each do |job|
                       begin
-                        Kubernetes::Manager::Job.new(self, job.name).watch_till_done!
+                        if ENV["KUBEDOG"]
+                          ruby2go_deploy_watcher("action" => "watch job", "resourceName" => job.name, "namespace" => release.namespace)
+                        else
+                          Kubernetes::Manager::Job.new(self, job.name).watch_till_done!
+                        end
                       rescue ::Exception => e
                         sentry_exception(e, extra: {"job-spec" => job.spec})
                         raise
@@ -219,7 +223,11 @@ module Dapp
                   ::Timeout::timeout(self.options[:timeout] || 300) do
                     deployment_managers.each {|deployment_manager|
                       if deployment_manager.should_watch?
-                        deployment_manager.watch_till_ready!
+                        if ENV["KUBEDOG"]
+                          ruby2go_deploy_watcher("action" => "watch deployment", "resourceName" => deployment_manager.name, "namespace" => release.namespace)
+                        else
+                          deployment_manager.watch_till_ready!
+                        end
                       end
                     }
                   end


### PR DESCRIPTION
Only enabled when `KUBEDOG=1` environment variable is set.