### PR TITLE
[go-deeper] Fix `error: /app/.gitignore: No such file or directory`

### DIFF
--- a/pkg/true_git/archive.go
+++ b/pkg/true_git/archive.go
@@ -87,7 +87,7 @@ func writeArchive(out io.Writer, gitDir, workTreeDir string, withSubmodules bool
 		}
 
 		baseName := filepath.Base(absPath)
-		for _, p := range []string{".git", ".gitmodules", ".gitkeep", ".gitignore"} {
+		for _, p := range []string{".git"} {
 			if baseName == p {
 				return nil
 			}


### PR DESCRIPTION
Do not exclude .gitignore, .gitmodules and .gitkeep from git archive.