### PR TITLE
Added "kill cord" to kill process when one of the parents is dead

### DIFF
--- a/bin/dapp
+++ b/bin/dapp
@@ -54,7 +54,7 @@ def set_gitlab_cancel_handler
       parents_pids.each do |pid|
         if not process_alive? pid
           home_dir = (ENV["DAPP_HOME"] || File.join(ENV["HOME"], ".dapp"))
-          File.open(File.join(home_dir, "cancelled"), "a") do |file|
+          File.open(File.join(home_dir, ".killed_pids"), "a") do |file|
             file.write "#{Process.pid}\n"
           end
 

--- a/pkg/kill_cord/kill_cord.go
+++ b/pkg/kill_cord/kill_cord.go
@@ -1,0 +1,126 @@
+package kill_cord
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/flant/dapp/pkg/dapp"
+)
+
+func Init() error {
+	if os.Getenv("GITLAB_CI") == "" {
+		return nil
+	}
+
+	parentsPids, err := getParents()
+	if err != nil {
+		return err
+	}
+
+	go run(parentsPids)
+
+	return nil
+}
+
+func run(parentsPids []int) {
+	for {
+		for _, pid := range parentsPids {
+			if isProcessAlive(pid) {
+				continue
+			}
+
+			ownPid := os.Getpid()
+
+			err := writePidToFile(os.Getpid(), filepath.Join(dapp.GetHomeDir(), ".killed_pids"))
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Kill cord error: %s\n", err)
+			}
+
+			syscall.Kill(ownPid, syscall.SIGINT)
+
+			return
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func writePidToFile(pid int, path string) error {
+	err := os.MkdirAll(filepath.Dir(path), os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(fmt.Sprintf("%d\n", pid))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getParents() ([]int, error) {
+	pid := os.Getpid()
+	parents := []int{}
+
+	for {
+		ppid, err := getProcessParentPid(pid)
+		if err != nil {
+			return nil, err
+		}
+		if ppid == 0 {
+			break
+		}
+		parents = append(parents, ppid)
+		pid = ppid
+	}
+
+	return parents, nil
+}
+
+func getProcessParentPid(pid int) (int, error) {
+	path := filepath.Join("/proc", fmt.Sprintf("%d", pid), "status")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return 0, nil
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lineParts := strings.Split(strings.TrimSpace(scanner.Text()), "\t")
+		if lineParts[0] == "PPid:" {
+			i, err := strconv.ParseInt(lineParts[1], 10, 32)
+			if err != nil {
+				return 0, err
+			}
+			return int(i), nil
+		}
+	}
+
+	return 0, nil
+}
+
+func isProcessAlive(pid int) bool {
+	err := syscall.Kill(pid, syscall.Signal(0))
+	if err == syscall.EPERM || err == nil {
+		return true
+	}
+	return false
+}

--- a/pkg/ruby2go/ruby2go.go
+++ b/pkg/ruby2go/ruby2go.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"syscall"
 
+	"github.com/flant/dapp/pkg/kill_cord"
 	"github.com/flant/dapp/pkg/util"
 )
 
@@ -62,6 +63,12 @@ func writeJsonObjectToFile(obj map[string]interface{}, path string) error {
 
 func RunCli(progname string, runFunc func(map[string]interface{}) (interface{}, error)) {
 	Trap()
+
+	err := kill_cord.Init()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Kill cord initialization error: %s\n", err)
+		os.Exit(1)
+	}
 
 	WorkingDir, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
* Gitlab Cancel Button will kill not only ruby-dapp, but also
  all child processes spawned by ruby-dapp. Fixed the case, when
  ruby-dapp has been killed, but ruby2go watcher process
  continues to work in background.

* Wait job-watcher only when helm release succeeded.
  Kill job-watcher otherwise.