### PR TITLE
Remove project tmp dir properly

### DIFF
--- a/cmd/dapp/bp/bp.go
+++ b/cmd/dapp/bp/bp.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flant/dapp/pkg/image"
 	"github.com/flant/dapp/pkg/lock"
 	"github.com/flant/dapp/pkg/logger"
+	"github.com/flant/dapp/pkg/project_tmp_dir"
 	"github.com/flant/dapp/pkg/ssh_agent"
 	"github.com/flant/dapp/pkg/true_git"
 )
@@ -96,6 +97,10 @@ func runBP(dimgsToProcess []string) error {
 		return err
 	}
 
+	if err := docker.Init(docker_authorizer.GetHomeDockerConfigDir()); err != nil {
+		return err
+	}
+
 	projectDir, err := common.GetProjectDir(&CommonCmdData)
 	if err != nil {
 		return fmt.Errorf("getting project dir failed: %s", err)
@@ -111,13 +116,11 @@ func runBP(dimgsToProcess []string) error {
 		return fmt.Errorf("getting project build dir failed: %s", err)
 	}
 
-	projectTmpDir, err := common.GetProjectTmpDir()
+	projectTmpDir, err := project_tmp_dir.Get()
 	if err != nil {
 		return fmt.Errorf("getting project tmp dir failed: %s", err)
 	}
-	if !docker.Debug() {
-		defer common.RemoveProjectTmpDir(projectTmpDir)
-	}
+	defer project_tmp_dir.Release(projectTmpDir)
 
 	dappfile, err := common.GetDappfile(projectDir)
 	if err != nil {

--- a/cmd/dapp/build/build.go
+++ b/cmd/dapp/build/build.go
@@ -13,6 +13,7 @@ import (
 	"github.com/flant/dapp/pkg/image"
 	"github.com/flant/dapp/pkg/lock"
 	"github.com/flant/dapp/pkg/logger"
+	"github.com/flant/dapp/pkg/project_tmp_dir"
 	"github.com/flant/dapp/pkg/ssh_agent"
 	"github.com/flant/dapp/pkg/true_git"
 )
@@ -69,6 +70,10 @@ func runBuild(dimgsToProcess []string) error {
 		return err
 	}
 
+	if err := docker.Init(docker_authorizer.GetHomeDockerConfigDir()); err != nil {
+		return err
+	}
+
 	projectDir, err := common.GetProjectDir(&CommonCmdData)
 	if err != nil {
 		return fmt.Errorf("getting project dir failed: %s", err)
@@ -84,13 +89,11 @@ func runBuild(dimgsToProcess []string) error {
 		return fmt.Errorf("getting project build dir failed: %s", err)
 	}
 
-	projectTmpDir, err := common.GetProjectTmpDir()
+	projectTmpDir, err := project_tmp_dir.Get()
 	if err != nil {
 		return fmt.Errorf("getting project tmp dir failed: %s", err)
 	}
-	if !docker.Debug() {
-		defer common.RemoveProjectTmpDir(projectTmpDir)
-	}
+	defer project_tmp_dir.Release(projectTmpDir)
 
 	dappfile, err := common.GetDappfile(projectDir)
 	if err != nil {

--- a/cmd/dapp/common/common.go
+++ b/cmd/dapp/common/common.go
@@ -3,7 +3,6 @@ package common
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -14,7 +13,6 @@ import (
 	"github.com/flant/dapp/pkg/config"
 	"github.com/flant/dapp/pkg/dapp"
 	"github.com/flant/dapp/pkg/git_repo"
-	"github.com/flant/dapp/pkg/logger"
 	"github.com/flant/dapp/pkg/slug"
 	"github.com/flant/kubedog/pkg/kube"
 )
@@ -133,17 +131,6 @@ func GetProjectDir(cmdData *CmdData) (string, error) {
 	}
 
 	return currentDir, nil
-}
-
-func GetProjectTmpDir() (string, error) {
-	return ioutil.TempDir(dapp.GetTmpDir(), "dapp-")
-}
-
-func RemoveProjectTmpDir(dir string) {
-	err := os.RemoveAll(dir)
-	if err != nil {
-		logger.LogWarningF("WARNING: unable to remove project tmp dir %s: %s\n", dir, err)
-	}
 }
 
 func GetProjectBuildDir(projectName string) (string, error) {

--- a/cmd/dapp/flush/flush.go
+++ b/cmd/dapp/flush/flush.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flant/dapp/pkg/dapp"
 	"github.com/flant/dapp/pkg/docker"
 	"github.com/flant/dapp/pkg/lock"
+	"github.com/flant/dapp/pkg/project_tmp_dir"
 )
 
 var CmdData struct {
@@ -69,13 +70,15 @@ func runFlush() error {
 	}
 
 	if CmdData.Repo != "" {
-		projectTmpDir, err := common.GetProjectTmpDir()
+		if err := docker.Init(docker_authorizer.GetHomeDockerConfigDir()); err != nil {
+			return err
+		}
+
+		projectTmpDir, err := project_tmp_dir.Get()
 		if err != nil {
 			return fmt.Errorf("getting project tmp dir failed: %s", err)
 		}
-		if !docker.Debug() {
-			defer common.RemoveProjectTmpDir(projectTmpDir)
-		}
+		defer project_tmp_dir.Release(projectTmpDir)
 
 		dockerAuthorizer, err := docker_authorizer.GetFlushDockerAuthorizer(projectTmpDir, CmdData.RegistryUsername, CmdData.RegistryPassword)
 		if err != nil {

--- a/cmd/dapp/gc/gc.go
+++ b/cmd/dapp/gc/gc.go
@@ -1,0 +1,70 @@
+package gc
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/flant/dapp/cmd/dapp/common"
+	"github.com/flant/dapp/cmd/dapp/docker_authorizer"
+	"github.com/flant/dapp/pkg/cleanup"
+	"github.com/flant/dapp/pkg/dapp"
+	"github.com/flant/dapp/pkg/docker"
+	"github.com/flant/dapp/pkg/lock"
+	"github.com/flant/dapp/pkg/project_tmp_dir"
+	"github.com/flant/dapp/pkg/true_git"
+)
+
+var CmdData struct {
+}
+
+var CommonCmdData common.CmdData
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "gc",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := runGC()
+			if err != nil {
+				return fmt.Errorf("gc failed: %s", err)
+			}
+			return nil
+		},
+	}
+
+	common.SetupTmpDir(&CommonCmdData, cmd)
+	common.SetupHomeDir(&CommonCmdData, cmd)
+
+	return cmd
+}
+
+func runGC() error {
+	if err := dapp.Init(*CommonCmdData.TmpDir, *CommonCmdData.HomeDir); err != nil {
+		return fmt.Errorf("initialization error: %s", err)
+	}
+
+	if err := lock.Init(); err != nil {
+		return err
+	}
+
+	if err := true_git.Init(); err != nil {
+		return err
+	}
+
+	if err := docker.Init(docker_authorizer.GetHomeDockerConfigDir()); err != nil {
+		return err
+	}
+
+	return lock.WithLock("gc", lock.LockOptions{}, func() error {
+		err := project_tmp_dir.GC()
+		if err != nil {
+			return fmt.Errorf("project tmp dir gc failed: %s", err)
+		}
+
+		if err := cleanup.RemoveLostTmpDappFiles(); err != nil {
+			return fmt.Errorf("unable to remove lost tmp dapp files: %s", err)
+		}
+
+		return nil
+	})
+}

--- a/cmd/dapp/main.go
+++ b/cmd/dapp/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flant/dapp/cmd/dapp/deploy"
 	"github.com/flant/dapp/cmd/dapp/dismiss"
 	"github.com/flant/dapp/cmd/dapp/flush"
+	"github.com/flant/dapp/cmd/dapp/gc"
 	"github.com/flant/dapp/cmd/dapp/lint"
 	"github.com/flant/dapp/cmd/dapp/push"
 	"github.com/flant/dapp/cmd/dapp/render"
@@ -60,6 +61,7 @@ func main() {
 		flush.NewCmd(),
 		sync.NewCmd(),
 		cleanup.NewCmd(),
+		gc.NewCmd(),
 
 		secretCmd(),
 		slugCmd(),

--- a/cmd/dapp/secret/edit/edit.go
+++ b/cmd/dapp/secret/edit/edit.go
@@ -13,6 +13,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 	"k8s.io/kubernetes/pkg/util/file"
@@ -21,7 +22,6 @@ import (
 	secret_common "github.com/flant/dapp/cmd/dapp/secret/common"
 	"github.com/flant/dapp/pkg/dapp"
 	"github.com/flant/dapp/pkg/deploy/secret"
-	"github.com/flant/dapp/pkg/docker"
 )
 
 var CmdData struct {
@@ -77,20 +77,9 @@ func secretEdit(m secret.Manager, filePath string, values bool) error {
 		return err
 	}
 
-	tmpFileName := "tmp_secret_file"
-	if values {
-		tmpFileName = "tmp_secret_file.yaml"
-	}
+	tmpFilePath := filepath.Join(dapp.GetTmpDir(), fmt.Sprintf("dapp-edit-secret-%s", uuid.NewV4().String()))
+	defer os.RemoveAll(tmpFilePath)
 
-	tmpDir, err := common.GetProjectTmpDir()
-	if err != nil {
-		return fmt.Errorf("getting project tmp dir failed: %s", err)
-	}
-	if !docker.Debug() {
-		defer common.RemoveProjectTmpDir(tmpDir)
-	}
-
-	tmpFilePath := filepath.Join(tmpDir, tmpFileName)
 	if err := createTmpEditedFile(tmpFilePath, data); err != nil {
 		return err
 	}

--- a/cmd/dapp/sync/sync.go
+++ b/cmd/dapp/sync/sync.go
@@ -11,6 +11,7 @@ import (
 	"github.com/flant/dapp/pkg/dapp"
 	"github.com/flant/dapp/pkg/docker"
 	"github.com/flant/dapp/pkg/lock"
+	"github.com/flant/dapp/pkg/project_tmp_dir"
 )
 
 var CmdData struct {
@@ -59,18 +60,20 @@ func runSync() error {
 		return err
 	}
 
+	if err := docker.Init(docker_authorizer.GetHomeDockerConfigDir()); err != nil {
+		return err
+	}
+
 	projectDir, err := common.GetProjectDir(&CommonCmdData)
 	if err != nil {
 		return fmt.Errorf("getting project dir failed: %s", err)
 	}
 
-	projectTmpDir, err := common.GetProjectTmpDir()
+	projectTmpDir, err := project_tmp_dir.Get()
 	if err != nil {
 		return fmt.Errorf("getting project tmp dir failed: %s", err)
 	}
-	if !docker.Debug() {
-		defer common.RemoveProjectTmpDir(projectTmpDir)
-	}
+	defer project_tmp_dir.Release(projectTmpDir)
 
 	projectName, err := common.GetProjectName(&CommonCmdData, projectDir)
 	if err != nil {

--- a/pkg/cleanup/lost_tmp_files.go
+++ b/pkg/cleanup/lost_tmp_files.go
@@ -1,0 +1,35 @@
+package cleanup
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/flant/dapp/pkg/dapp"
+	"github.com/flant/dapp/pkg/logger"
+)
+
+func RemoveLostTmpDappFiles() error {
+	tmpFiles, err := ioutil.ReadDir(dapp.GetTmpDir())
+	if err != nil {
+		return fmt.Errorf("unable to list tmp files in %s: %s", dapp.GetTmpDir(), err)
+	}
+
+	filesToRemove := []string{}
+	for _, finfo := range tmpFiles {
+		if strings.HasPrefix(finfo.Name(), "dapp") {
+			filesToRemove = append(filesToRemove, filepath.Join(dapp.GetTmpDir(), finfo.Name()))
+		}
+	}
+
+	for _, file := range filesToRemove {
+		err := os.RemoveAll(file)
+		if err != nil {
+			logger.LogWarningF("WARNING: unable to remove %s: %s\n", file, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cleanup/reset.go
+++ b/pkg/cleanup/reset.go
@@ -2,15 +2,12 @@ package cleanup
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/docker/docker/api/types/filters"
 
 	"github.com/flant/dapp/pkg/dapp"
-	"github.com/flant/dapp/pkg/logger"
 )
 
 func ResetAll(options CommonOptions) error {
@@ -26,23 +23,8 @@ func ResetAll(options CommonOptions) error {
 		return err
 	}
 
-	tmpFiles, err := ioutil.ReadDir(dapp.GetTmpDir())
-	if err != nil {
-		return fmt.Errorf("unable to list tmp files in %s: %s", dapp.GetTmpDir(), err)
-	}
-
-	filesToRemove := []string{}
-	for _, finfo := range tmpFiles {
-		if strings.HasPrefix(finfo.Name(), "dapp") {
-			filesToRemove = append(filesToRemove, filepath.Join(dapp.GetTmpDir(), finfo.Name()))
-		}
-	}
-
-	for _, file := range filesToRemove {
-		err := os.RemoveAll(file)
-		if err != nil {
-			logger.LogWarningF("WARNING: unable to remove %s: %s\n", file, err)
-		}
+	if err := RemoveLostTmpDappFiles(); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/dapp/dapp.go
+++ b/pkg/dapp/dapp.go
@@ -48,36 +48,3 @@ func Init(tmpDirOption, homeDirOption string) error {
 
 	return nil
 }
-
-/* TODO: will be needed for single go-dapp binary
-func Init() error {
-		TmpDir, err = ioutil.TempDir("", "dapp-")
-		if err != nil {
-			return fmt.Errorf("cannot create temporary dir: %s", err)
-		}
-
-		interruptCh := make(chan os.Signal, 1)
-		signal.Notify(interruptCh, syscall.SIGINT, syscall.SIGTERM)
-
-		go func() {
-			<-interruptCh
-			err := Terminate()
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error terminating dapp: %s", err)
-			}
-			fmt.Fprintf(os.Stderr, "Exiting")
-			os.Exit(1)
-		}()
-
-	return nil
-}
-
-func Terminate() error {
-		err := os.RemoveAll(TmpDir)
-		if err != nil {
-			return fmt.Errorf("cannot remove temporary dir: %s", err)
-		}
-
-	return nil
-}
-*/

--- a/pkg/dappdeps/base.go
+++ b/pkg/dappdeps/base.go
@@ -7,10 +7,14 @@ import (
 
 const BASE_VERSION = "0.2.3"
 
+func BaseImageName() string {
+	return fmt.Sprintf("dappdeps/base:%s", BASE_VERSION)
+}
+
 func BaseContainer() (string, error) {
 	container := &container{
 		Name:      fmt.Sprintf("dappdeps_base_%s", BASE_VERSION),
-		ImageName: fmt.Sprintf("dappdeps/base:%s", BASE_VERSION),
+		ImageName: BaseImageName(),
 		Volume:    fmt.Sprintf("/.dapp/deps/base/%s", BASE_VERSION),
 	}
 

--- a/pkg/project_tmp_dir/project_tmp_dir.go
+++ b/pkg/project_tmp_dir/project_tmp_dir.go
@@ -1,0 +1,167 @@
+package project_tmp_dir
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/flant/dapp/pkg/lock"
+
+	"github.com/flant/dapp/pkg/dapp"
+	"github.com/flant/dapp/pkg/dappdeps"
+	"github.com/flant/dapp/pkg/docker"
+)
+
+func GetCreatedTmpDirs() string {
+	return filepath.Join(dapp.GetHomeDir(), "tmp", "created")
+}
+
+func GetReleasedTmpDirs() string {
+	return filepath.Join(dapp.GetHomeDir(), "tmp", "released")
+}
+
+func Get() (string, error) {
+	dir, err := ioutil.TempDir(dapp.GetTmpDir(), "dapp-")
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(GetCreatedTmpDirs(), os.ModePerm); err != nil {
+		return "", fmt.Errorf("unable to create dir %s: %s", GetCreatedTmpDirs(), err)
+	}
+
+	createdDir := filepath.Join(GetCreatedTmpDirs(), filepath.Base(dir))
+	if err := os.Symlink(dir, createdDir); err != nil {
+		os.RemoveAll(dir)
+		return "", err
+	}
+
+	gcShouldRun := false
+
+	if _, err := os.Stat(GetReleasedTmpDirs()); !os.IsNotExist(err) {
+		releasedDirs, err := ioutil.ReadDir(GetReleasedTmpDirs())
+		if err != nil {
+			return "", fmt.Errorf("unable to list released tmp dirs in %s: %s", GetReleasedTmpDirs(), err)
+		}
+
+		if len(releasedDirs) > 50 {
+			gcShouldRun = true
+		}
+	}
+
+	if gcShouldRun {
+		err := lock.WithLock("gc", lock.LockOptions{}, GC)
+		if err != nil {
+			return "", fmt.Errorf("GC failed: %s", err)
+		}
+	}
+
+	return dir, nil
+}
+
+func GC() error {
+	var releasedDirs []os.FileInfo
+	var createdDirs []os.FileInfo
+
+	if _, err := os.Stat(GetReleasedTmpDirs()); !os.IsNotExist(err) {
+		var err error
+		releasedDirs, err = ioutil.ReadDir(GetReleasedTmpDirs())
+		if err != nil {
+			return fmt.Errorf("unable to list released tmp dirs in %s: %s", GetReleasedTmpDirs(), err)
+		}
+	}
+
+	if _, err := os.Stat(GetCreatedTmpDirs()); !os.IsNotExist(err) {
+		var err error
+		createdDirs, err = ioutil.ReadDir(GetCreatedTmpDirs())
+		if err != nil {
+			return fmt.Errorf("unable to list created tmp dirs in %s: %s", GetReleasedTmpDirs(), err)
+		}
+	}
+
+	tmpDirsToRemove := []string{}
+	filesToUnlink := []string{}
+
+	for _, dirInfo := range releasedDirs {
+		link := filepath.Join(GetReleasedTmpDirs(), dirInfo.Name())
+
+		origDir, err := os.Readlink(link)
+		if err != nil {
+			return fmt.Errorf("unable to read link %s: %s", link, err)
+		}
+
+		tmpDirsToRemove = append(tmpDirsToRemove, origDir)
+		filesToUnlink = append(filesToUnlink, link)
+	}
+
+	now := time.Now()
+	for _, dirInfo := range createdDirs {
+		if now.Sub(dirInfo.ModTime()) < 2*time.Hour {
+			continue
+		}
+
+		link := filepath.Join(GetCreatedTmpDirs(), dirInfo.Name())
+
+		origDir, err := os.Readlink(link)
+		if err != nil {
+			return fmt.Errorf("unable to read link %s: %s", link, err)
+		}
+
+		tmpDirsToRemove = append(tmpDirsToRemove, origDir)
+		filesToUnlink = append(filesToUnlink, link)
+	}
+
+	if len(tmpDirsToRemove) > 0 {
+		if err := removeDirs(tmpDirsToRemove); err != nil {
+			return fmt.Errorf("unable to remove dirs %s: %s", strings.Join(tmpDirsToRemove, ", "), err)
+		}
+	}
+
+	for _, file := range filesToUnlink {
+		if err := os.Remove(file); err != nil {
+			return fmt.Errorf("unable to remove %s: %s", file, err)
+		}
+	}
+
+	return nil
+}
+
+func Release(dir string) error {
+	if err := os.MkdirAll(GetReleasedTmpDirs(), os.ModePerm); err != nil {
+		return fmt.Errorf("unable to create dir %s: %s", GetReleasedTmpDirs(), err)
+	}
+
+	releasedDir := filepath.Join(GetReleasedTmpDirs(), filepath.Base(dir))
+	if err := os.Symlink(dir, releasedDir); err != nil {
+		return err
+	}
+
+	createdDir := filepath.Join(GetCreatedTmpDirs(), filepath.Base(dir))
+	if err := os.Remove(createdDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func removeDirs(dirs []string) error {
+	toolchainContainerName, err := dappdeps.ToolchainContainer()
+	if err != nil {
+		return err
+	}
+
+	args := []string{
+		"--rm",
+		"--volumes-from", toolchainContainerName,
+		"--volume", fmt.Sprintf("%s:%s", dapp.GetTmpDir(), dapp.GetTmpDir()),
+		dappdeps.BaseImageName(),
+		dappdeps.RmBinPath(), "-rf",
+	}
+
+	args = append(args, dirs...)
+
+	return docker.CliRun(args...)
+}


### PR DESCRIPTION
Dapp will remove tmp dirs from builds in special "garbage collection" procedure. Which will occur when there are more than 50 tmp dirs accumulated.

To remove such a dir dapp needs to run special service container. This procedure consumes some time, valuable for best the user experience. This is why dapp removes such folders in delayed manner.

---
Also added special `dapp gc` command to force removal of:
- build/deploy tmp dirs, that are not being used;
- lost git patches and archives generated by dapp;
- lost dapp temporal secret edit files.

This command can be safely run during any other dapp command is working.

---
Remove `/tmp/dapp*` files in `dapp reset`

Action may require root privileges.

Action will remove not only project tmp dirs, but also:
- lost git patches and archives generated by dapp;
- lost dapp temporal secret edit files.

https://github.com/flant/dapp/issues/1166