### PR TITLE
Fix gitlab authentication problem with docker registry 2.7+ (0.31)

### DIFF
--- a/lib/dapp/dimg/docker_registry/base/authorization.rb
+++ b/lib/dapp/dimg/docker_registry/base/authorization.rb
@@ -29,8 +29,23 @@ module Dapp
             [:realm, :service, :scope].map do |option|
               /#{option}="([[^"].]*)/ =~ header
               next unless Regexp.last_match(1)
-              [option, Regexp.last_match(1)]
+
+              option_value = begin
+                if option == :scope
+                  handle_scope_option(Regexp.last_match(1))
+                else
+                  Regexp.last_match(1)
+                end
+              end
+
+              [option, option_value]
             end.compact.to_h
+          end
+
+          def handle_scope_option(resourcescope)
+            resource_type, resource_name, actions = resourcescope.split(":")
+            actions                               = actions.split(",").map { |action| action == "delete" ? "*" : action }.join(",")
+            [resource_type, resource_name, actions].join(":")
           end
 
           def authorization_auth


### PR DESCRIPTION
GitLab authorization service doesn't support full implementation of Docker registry scope (JWT authentication), including 'delete' action since docker registry 2.7+ (https://github.com/docker/distribution/commit/ccb839e0e30c3b6992fb4084dfd6550d0ddd4d1a)